### PR TITLE
Full Commit SHA Cleanup

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.8.2
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
         with:
           config-file: '.github/dependency-review-config.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Node
-        uses: actions/setup-node@v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.1.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           release-type: simple

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -87,10 +87,10 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Node
-        uses: actions/setup-node@v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.1.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
@@ -99,7 +99,7 @@ jobs:
         run: npm ci --ignore-scripts --omit=dev
 
       - name: ⚡️ SCA
-        uses: ministryofjustice/devsecops-actions/sca@v1.3.0
+        uses: ministryofjustice/devsecops-actions/sca@f965eb1771ec66cfc41d7d57dc607fa6dfbc10ed # v1.3.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}" # Mandatory
           dependency-review-config-file: "./.github/dependency-review-config.yml" # Optional

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,6 @@
 ### Python
 
 - Python 3.7+ (Self Service or [Direct Download](https://www.python.org/downloads/))
-- NodeJS (Self-Service or [Direct Download](https://nodejs.org/en/download))
 
 ### Brew
 


### PR DESCRIPTION
# Introduction :pencil2:

Reverts some actions-related changes in #11 by ensuring adherence to actions being pinned by commit SHA, with version provided in a comment.

## Resolution :heavy_check_mark:

- Actions such as checkout, setup-node, etc are all pinned to the corresponding commit sha, with the version added as a comment inline

## Miscellaneous :heavy_plus_sign:

Drops mention of NodeJS from `docs/setup.md` as not required

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>