### PR TITLE
Add GitHub App authentication flow and update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Set the following environment variables:
 
 In CI/CD, map your secrets manager values to these environment variable names.
 
-> Internal note: GitHub App credentials are stored as repository secrets and in the 1Password vault item `Developer Experience GitHub Audit`, with fields `GH_APP_ID` and `GH_APP_PRIVATE_KEY`.
-
 For local runs, export values individually:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,42 @@ Follow the dedicated setup guidance under `docs/setup.md` to get all pre-requisi
 
 [Setup Docs](./docs/setup.md)
 
+## Authentication
+
+Scripts resolve authentication in this order:
+
+1. `GITHUB_TOKEN` or `GH_TOKEN`
+2. GitHub App credentials (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`)
+3. GitHub CLI token from `~/.config/gh/hosts.yml`
+
+### GitHub App setup (recommended)
+
+Set the following environment variables:
+
+- `GH_APP_ID` (or `GITHUB_APP_ID`)
+- `GH_APP_PRIVATE_KEY` (or `GITHUB_APP_PRIVATE_KEY`) with the full PEM key content
+- `GH_APP_INSTALLATION_ID` (or `GITHUB_APP_INSTALLATION_ID`) **or** `GH_ORG` / `GITHUB_ORG` for installation auto-discovery
+
+In CI/CD, map your secrets manager values to these environment variable names.
+
+> Internal note: GitHub App credentials are stored as repository secrets and in the 1Password vault item `Developer Experience GitHub Audit`, with fields `GH_APP_ID` and `GH_APP_PRIVATE_KEY`.
+
+For local runs, export values individually:
+
+```bash
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
+
+# Optional: set explicitly if you don't want installation auto-discovery
+# export GH_APP_INSTALLATION_ID="<your_installation_id>"
+
+# Optional: force GitHub App path by clearing PAT vars
+unset GH_TOKEN GITHUB_TOKEN
+```
+
+> Note: private-key file path variables are not used; provide the key content in env vars.
+
 ## Scripts
 
 ### 1. `list_repos.py` - List and Audit Organization Repositories
@@ -91,7 +127,6 @@ python audit_repo.py <owner/repo> [options]
 
 ```bash
 # Audit a repository
-export GITHUB_TOKEN=ghp_xxxx
 python audit_repo.py github/cli
 
 # Audit and save to custom database
@@ -182,6 +217,7 @@ python org_security_posture.py <org> [--excel path] [--json] [--repo-limit N] [-
 - JSON to stdout by default
 - Excel workbook output when `--excel` is supplied
 - Cached results stored in `.posture_cache_<org>.pkl` for reuse on later runs
+- `org_rulesets_count` may show `no_access (403)` when the app lacks org rulesets permission
 
 **Examples:**
 
@@ -217,7 +253,6 @@ python dashboard.py [options]
 
 ```bash
 # Start dashboard with default database
-export GITHUB_TOKEN=ghp_xxxx
 python dashboard.py
 
 # Start with custom database
@@ -271,8 +306,11 @@ python testEnv.py
 # In Jupyter cell
 !python testEnv.py
 
-# With custom token
-export GH_TOKEN=ghp_xxxx
+# With GitHub App credentials exported directly
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
+unset GH_TOKEN GITHUB_TOKEN
 python testEnv.py
 ```
 
@@ -318,14 +356,19 @@ Each repo is assigned risk flags:
 ### Single Organization Audit
 
 ```bash
-# 1. Audit all repos in organization
-export GITHUB_TOKEN=ghp_xxxx
+# 1. Load GitHub App credentials
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
+unset GH_TOKEN GITHUB_TOKEN
+
+# 2. Audit all repos in organization
 python list_repos.py myorg --excel audit_results.xlsx
 
-# 2. Launch dashboard to explore results
+# 3. Launch dashboard to explore results
 python dashboard.py
 
-# 3. Click on repos to view details or run deeper audits
+# 4. Click on repos to view details or run deeper audits
 ```
 
 ### Archive Review Workflow
@@ -361,8 +404,13 @@ owner/repo2
 owner/repo3
 EOF
 
+# Load GitHub App credentials
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
+unset GH_TOKEN GITHUB_TOKEN
+
 # Audit them
-export GITHUB_TOKEN=ghp_xxxx
 python list_repos.py owner --repo-file repos.txt --audit-db
 
 # View in dashboard
@@ -372,8 +420,13 @@ python dashboard.py
 ### Continuous Monitoring
 
 ```bash
+# Load GitHub App credentials (once per shell/session)
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
+unset GH_TOKEN GITHUB_TOKEN
+
 # Re-run audit with `--audit-db` to update the dashboard database
-export GITHUB_TOKEN=ghp_xxxx
 python list_repos.py myorg --audit-db
 
 # Dashboard automatically shows updated data
@@ -412,14 +465,12 @@ This will diagnose differences in PATH, HOME, and token availability.
 ### Export audit to XLSX report
 
 ```bash
-export GITHUB_TOKEN=ghp_xxxx
 python list_repos.py github --limit 20 --excel github_audit.xlsx
 ```
 
 ### Audit specific critical repos
 
 ```bash
-export GITHUB_TOKEN=ghp_xxxx
 python audit_repo.py github/cli > cli_audit.json
 python audit_repo.py github/copilot-docs > copilot_audit.json
 ```
@@ -427,7 +478,6 @@ python audit_repo.py github/copilot-docs > copilot_audit.json
 ### Use dashboard to identify high-risk repos
 
 ```bash
-export GITHUB_TOKEN=ghp_xxxx
 python list_repos.py myorg --audit-db
 python dashboard.py
 # Filter by "Show only repos with flags"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,22 +19,35 @@ Most of the prerequisites will require `homebrew` and the `brew` utility, this c
 ### Github Setup
 
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
-- GitHub personal access token (PAT) with appropriate scopes (minimum: `repo`) - [Guidance](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- GitHub App credentials available for `Developer Experience GitHub Audit`
+  - `GH_APP_ID` (or `GITHUB_APP_ID`)
+  - `GH_APP_PRIVATE_KEY` (or `GITHUB_APP_PRIVATE_KEY`) with full PEM key content
+  - `GH_APP_INSTALLATION_ID` (or `GITHUB_APP_INSTALLATION_ID`) **or** `GH_ORG` / `GITHUB_ORG` for installation auto-discovery
 - Note: If you are contributing to this repository, signed commits are required - guidance is available on how to do this via SSH or GPG keys here: [guidance](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ### Environment Variables
 
-Set your GitHub token as an environment variable:
+Set GitHub App credentials as environment variables:
 
 ```bash
-# Using a personal access token
-export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+export GH_APP_ID="<your_app_id>"
+export GH_ORG="<your_org>"
+export GH_APP_PRIVATE_KEY="$(cat /path/to/github-app-private-key.pem)"
 
-# Or if using the GitHub CLI default:
-export GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# Optional: set explicitly if you don't want installation auto-discovery
+# export GH_APP_INSTALLATION_ID="<your_installation_id>"
+
+# Optional: force GitHub App path by clearing PAT vars
+unset GH_TOKEN GITHUB_TOKEN
 ```
 
-The tools will automatically use whichever token is available (checks both `GH_TOKEN` and `GITHUB_TOKEN`).
+Authentication resolution order is:
+
+1. `GITHUB_TOKEN` or `GH_TOKEN`
+2. GitHub App credentials (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`)
+3. GitHub CLI token from `~/.config/gh/hosts.yml`
+
+If you want to ensure app-only auth is used, keep PAT variables unset.
 
 ### Compliance Tooling
 
@@ -63,7 +76,7 @@ Optionally, run pre-commit against all files:
 pre-commit run --all-files
 ```
 
-Authenticate to the Github Docker Container Registry with your PAT, providing your username after the `-u` flag and your Github password upon command execution:
+Authenticate to the Github Docker Container Registry using your GitHub CLI auth token, providing your username after the `-u` flag:
 
 ```shell
 gh auth token | docker login ghcr.io -u <github username> --password-stdin

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,7 +22,7 @@ Most of the prerequisites will require `homebrew` and the `brew` utility, this c
 - GitHub App credentials available for `Developer Experience GitHub Audit`
   - `GH_APP_ID` (or `GITHUB_APP_ID`)
   - `GH_APP_PRIVATE_KEY` (or `GITHUB_APP_PRIVATE_KEY`) with full PEM key content
-  - `GH_APP_INSTALLATION_ID` (or `GITHUB_APP_INSTALLATION_ID`) **or** `GH_ORG` / `GITHUB_ORG` for installation auto-discovery
+  - `GH_APP_INSTALLATION_ID` (or `GITHUB_APP_INSTALLATION_ID`) **or** `GH_ORG` / `GITHUB_ORG` / `GITHUB_OWNER` for installation auto-discovery
 - Note: If you are contributing to this repository, signed commits are required - guidance is available on how to do this via SSH or GPG keys here: [guidance](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ### Environment Variables

--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -3,4 +3,6 @@ openpyxl>=3.0.0
 pandas>=1.3.0
 pyyaml>=6.0
 requests>=2.28.0
+PyJWT>=2.8.0
+cryptography>=42.0.0
 ruff>=0.15.5

--- a/utils.py
+++ b/utils.py
@@ -178,10 +178,14 @@ def _request_with_backoff(
 def _get_github_token() -> str:
     """Return a GitHub token, caching the result.
 
-    Tokens are first looked up in the environment variable
-    ``GITHUB_TOKEN`` (or ``GH_TOKEN``); if absent we fall back to the
-    GitHub CLI configuration file.  The value is cached in a module-level
-    variable so repeated calls are cheap.
+    Resolution order:
+
+    1. ``GITHUB_TOKEN`` or ``GH_TOKEN`` from environment variables.
+    2. GitHub App installation token (when GitHub App env vars are set).
+    3. GitHub CLI token from ``~/.config/gh/hosts.yml``.
+
+    The resolved value is cached in a module-level variable so repeated
+    calls are cheap.
     """
     global _TOKEN
     if _TOKEN:

--- a/utils.py
+++ b/utils.py
@@ -34,9 +34,7 @@ def _resolve_github_app_installation_id(
         return installation_id
 
     org_login = (
-        os.getenv("GH_ORG")
-        or os.getenv("GITHUB_ORG")
-        or os.getenv("GITHUB_OWNER")
+        os.getenv("GH_ORG") or os.getenv("GITHUB_ORG") or os.getenv("GITHUB_OWNER")
     )
     if not org_login:
         raise RuntimeError(
@@ -61,7 +59,15 @@ def _resolve_github_app_installation_id(
             if isinstance(account, str):
                 installation_accounts.append(account)
                 if account.lower() == org_login.lower():
-                    return str(installation.get("id"))
+                    installation_id_value = installation.get("id")
+                    if installation_id_value is None or not isinstance(
+                        installation_id_value, (int, str)
+                    ):
+                        raise RuntimeError(
+                            "GitHub App installation list response did not include a valid "
+                            f"'id' for installation with account '{account}'."
+                        )
+                    return str(installation_id_value)
 
         if len(installations) < 100:
             break

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import time
+from datetime import datetime
 from urllib.parse import parse_qs, urlparse
 from typing import Any, Dict, List, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -12,7 +13,21 @@ import requests
 
 # module‑level globals used to cache the GitHub token and HTTP session
 _TOKEN: Optional[str] = None
+_TOKEN_EXPIRES_AT: Optional[float] = None
+_TOKEN_SOURCE: Optional[str] = None
 _SESSION: Optional[requests.Session] = None
+_APP_TOKEN_REFRESH_SKEW_SECONDS = 120
+
+
+def _parse_iso8601_to_epoch(value: Any) -> Optional[float]:
+    """Parse an ISO-8601 timestamp string to epoch seconds."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
+        return None
 
 
 def _read_github_app_private_key() -> Optional[str]:
@@ -39,7 +54,7 @@ def _resolve_github_app_installation_id(
     if not org_login:
         raise RuntimeError(
             "GitHub App auth requires GH_APP_INSTALLATION_ID (or GITHUB_APP_INSTALLATION_ID), "
-            "or GH_ORG/GITHUB_ORG to auto-resolve the installation."
+            "or GH_ORG/GITHUB_ORG/GITHUB_OWNER to auto-resolve the installation."
         )
 
     installation_accounts: List[str] = []
@@ -79,8 +94,8 @@ def _resolve_github_app_installation_id(
     )
 
 
-def _get_github_app_installation_token() -> Optional[str]:
-    """Return a GitHub App installation token when app env vars are configured."""
+def _get_github_app_installation_token() -> Optional[Tuple[str, Optional[float]]]:
+    """Return (token, expires_at_epoch) when GitHub App auth is configured."""
     app_id = os.getenv("GH_APP_ID") or os.getenv("GITHUB_APP_ID")
     if not app_id:
         return None
@@ -117,21 +132,22 @@ def _get_github_app_installation_token() -> Optional[str]:
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    sess = requests.Session()
-    installation_id = _resolve_github_app_installation_id(sess, headers)
-    token_resp = sess.post(
-        f"https://api.github.com/app/installations/{installation_id}/access_tokens",
-        headers=headers,
-        timeout=30,
-    )
-    token_resp.raise_for_status()
-    token_data = token_resp.json()
-    token = token_data.get("token")
-    if not token:
-        raise RuntimeError(
-            "GitHub App access token response did not include a token value."
+    with requests.Session() as sess:
+        installation_id = _resolve_github_app_installation_id(sess, headers)
+        token_resp = sess.post(
+            f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+            headers=headers,
+            timeout=30,
         )
-    return token
+        token_resp.raise_for_status()
+        token_data = token_resp.json()
+        token = token_data.get("token")
+        if not token:
+            raise RuntimeError(
+                "GitHub App access token response did not include a token value."
+            )
+        expires_at = _parse_iso8601_to_epoch(token_data.get("expires_at"))
+        return token, expires_at
 
 
 def _rate_limit_retry_delay(resp: requests.Response, attempt: int) -> int:
@@ -190,21 +206,34 @@ def _get_github_token() -> str:
     2. GitHub App installation token (when GitHub App env vars are set).
     3. GitHub CLI token from ``~/.config/gh/hosts.yml``.
 
-    The resolved value is cached in a module-level variable so repeated
-    calls are cheap.
+    Environment and GitHub CLI tokens are cached. GitHub App installation
+    tokens are cached and refreshed before expiry.
     """
-    global _TOKEN
+    global _TOKEN, _TOKEN_EXPIRES_AT, _TOKEN_SOURCE
     if _TOKEN:
-        return _TOKEN
+        if _TOKEN_SOURCE != "app":
+            return _TOKEN
+        if _TOKEN_EXPIRES_AT is not None and time.time() < (
+            _TOKEN_EXPIRES_AT - _APP_TOKEN_REFRESH_SKEW_SECONDS
+        ):
+            return _TOKEN
+        _TOKEN = None
+        _TOKEN_EXPIRES_AT = None
+        _TOKEN_SOURCE = None
 
     token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
     if token:
         _TOKEN = token
-        return token
+        _TOKEN_EXPIRES_AT = None
+        _TOKEN_SOURCE = "env"
+        return _TOKEN
 
-    app_token = _get_github_app_installation_token()
-    if app_token:
+    app_token_details = _get_github_app_installation_token()
+    if app_token_details:
+        app_token, app_token_expires_at = app_token_details
         _TOKEN = app_token
+        _TOKEN_EXPIRES_AT = app_token_expires_at
+        _TOKEN_SOURCE = "app"
         return app_token
 
     # gh CLI config fallback
@@ -219,6 +248,8 @@ def _get_github_token() -> str:
                     oauth_token = config["github.com"].get("oauth_token")
                     if oauth_token:
                         _TOKEN = oauth_token
+                        _TOKEN_EXPIRES_AT = None
+                        _TOKEN_SOURCE = "gh_cli"
                         return oauth_token
     except Exception:
         pass
@@ -236,16 +267,21 @@ def _get_session() -> requests.Session:
     speeds up multiple API calls in a row.
     """
     global _SESSION
-    if _SESSION is None:
-        token = _get_github_token()
-        sess = requests.Session()
-        sess.headers.update(
-            {
-                "Authorization": f"token {token}",
-                "Accept": "application/vnd.github.v3+json",
-            }
-        )
-        _SESSION = sess
+    token = _get_github_token()
+    expected_authorization = f"token {token}"
+    if _SESSION is not None:
+        current_authorization = _SESSION.headers.get("Authorization")
+        if current_authorization == expected_authorization:
+            return _SESSION
+
+    sess = requests.Session()
+    sess.headers.update(
+        {
+            "Authorization": expected_authorization,
+            "Accept": "application/vnd.github.v3+json",
+        }
+    )
+    _SESSION = sess
     return _SESSION
 
 

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,119 @@ _TOKEN: Optional[str] = None
 _SESSION: Optional[requests.Session] = None
 
 
+def _read_github_app_private_key() -> Optional[str]:
+    """Return GitHub App private key from environment variable content."""
+    key_value = os.getenv("GH_APP_PRIVATE_KEY") or os.getenv("GITHUB_APP_PRIVATE_KEY")
+    if key_value:
+        return key_value.replace("\\n", "\n")
+    return None
+
+
+def _resolve_github_app_installation_id(
+    sess: requests.Session, headers: Dict[str, str]
+) -> str:
+    """Resolve GitHub App installation ID from env or org name."""
+    installation_id = os.getenv("GH_APP_INSTALLATION_ID") or os.getenv(
+        "GITHUB_APP_INSTALLATION_ID"
+    )
+    if installation_id:
+        return installation_id
+
+    org_login = (
+        os.getenv("GH_ORG")
+        or os.getenv("GITHUB_ORG")
+        or os.getenv("GITHUB_OWNER")
+    )
+    if not org_login:
+        raise RuntimeError(
+            "GitHub App auth requires GH_APP_INSTALLATION_ID (or GITHUB_APP_INSTALLATION_ID), "
+            "or GH_ORG/GITHUB_ORG to auto-resolve the installation."
+        )
+
+    installation_accounts: List[str] = []
+    for page in range(1, 11):
+        resp = sess.get(
+            f"https://api.github.com/app/installations?per_page=100&page={page}",
+            headers=headers,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        installations = resp.json()
+        if not isinstance(installations, list) or not installations:
+            break
+
+        for installation in installations:
+            account = (installation.get("account") or {}).get("login")
+            if isinstance(account, str):
+                installation_accounts.append(account)
+                if account.lower() == org_login.lower():
+                    return str(installation.get("id"))
+
+        if len(installations) < 100:
+            break
+
+    accounts = ", ".join(sorted(set(installation_accounts)))
+    raise RuntimeError(
+        f"No GitHub App installation found for org '{org_login}'. "
+        f"Visible installations: {accounts or 'none'}."
+    )
+
+
+def _get_github_app_installation_token() -> Optional[str]:
+    """Return a GitHub App installation token when app env vars are configured."""
+    app_id = os.getenv("GH_APP_ID") or os.getenv("GITHUB_APP_ID")
+    if not app_id:
+        return None
+
+    private_key = _read_github_app_private_key()
+    if not private_key:
+        raise RuntimeError(
+            "GitHub App auth requested via GH_APP_ID/GITHUB_APP_ID but no private key was provided. "
+            "Set GH_APP_PRIVATE_KEY (or GITHUB_APP_PRIVATE_KEY)."
+        )
+
+    try:
+        import jwt
+    except ImportError as exc:
+        raise RuntimeError(
+            "GitHub App authentication requires PyJWT and cryptography. "
+            "Install them with: pip install PyJWT cryptography"
+        ) from exc
+
+    now = int(time.time())
+    app_jwt = jwt.encode(
+        {
+            "iat": now - 60,
+            "exp": now + 540,
+            "iss": str(app_id),
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    headers = {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    sess = requests.Session()
+    installation_id = _resolve_github_app_installation_id(sess, headers)
+    token_resp = sess.post(
+        f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+        headers=headers,
+        timeout=30,
+    )
+    token_resp.raise_for_status()
+    token_data = token_resp.json()
+    token = token_data.get("token")
+    if not token:
+        raise RuntimeError(
+            "GitHub App access token response did not include a token value."
+        )
+    return token
+
+
 def _rate_limit_retry_delay(resp: requests.Response, attempt: int) -> int:
     """Return backoff delay in seconds for a 403 response.
 
@@ -79,6 +192,11 @@ def _get_github_token() -> str:
         _TOKEN = token
         return token
 
+    app_token = _get_github_app_installation_token()
+    if app_token:
+        _TOKEN = app_token
+        return app_token
+
     # gh CLI config fallback
     try:
         gh_config_path = os.path.expanduser("~/.config/gh/hosts.yml")
@@ -96,7 +214,8 @@ def _get_github_token() -> str:
         pass
 
     raise RuntimeError(
-        "No GitHub token found. Set GITHUB_TOKEN or GH_TOKEN env var or configure gh CLI."
+        "No GitHub token found. Set GITHUB_TOKEN/GH_TOKEN, or configure GH_APP_ID with a "
+        "GitHub App private key, or configure gh CLI."
     )
 
 


### PR DESCRIPTION
# Introduction :pencil2:
This PR migrates authentication from personal PAT usage to GitHub App credentials and updates the documentation to reflect the new recommended flow.
Related feature: GitHub App-based authentication for repository discovery and audit scripts.

## Resolution :heavy_check_mark:

- Added GitHub App authentication support in [utils.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- reads private key content from GH_APP_PRIVATE_KEY or GITHUB_APP_PRIVATE_KEY
- generates an app JWT
- resolves installation via GH_APP_INSTALLATION_ID/GITHUB_APP_INSTALLATION_ID or org auto-discovery
- exchanges JWT for an installation access token
- Preserved backward-compatible auth order in [utils.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): PAT env vars first, then GitHub App, then GitHub CLI token fallback.
- Improved auth error messaging for missing or incomplete GitHub App configuration.

## Updated [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include:
authentication order

- required GitHub App environment variables
- local export-based setup instructions
- note that org rulesets may return 403 when app permissions are insufficient

## Miscellaneous :heavy_plus_sign:

- Replaced PAT-focused examples with GitHub App examples in [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Added guidance to unset GH_TOKEN and GITHUB_TOKEN when forcing app-only validation.
- Added internal documentation note on credential storage location (repository secrets and 1Password entry).

## Screenshot(s) :camera_flash:
<details> <summary>Show/hide</summary>

No UI screenshots for this PR (authentication and documentation changes only).

</details>