### PR TITLE
Refactor/core cleanup

### DIFF
--- a/core/github_api.py
+++ b/core/github_api.py
@@ -44,12 +44,14 @@ from core.models import (
     CommunityProfile,
     DependencyGraphData,
     ForkTemplateData,
+    LatestWorkflowRunData,
     OrgActionsData,
     OrgAuditLogData,
     OrgCodeScanningAlertsData,
     OrgMembersData,
     OrgOutsideCollaboratorsData,
     OrgOverviewData,
+    RepoActionsPermissionsData,
     OrgRulesetsData,
     OrgSecretScanningAlertsData,
     OrgTeamsData,
@@ -161,38 +163,6 @@ def dependency_supply_chain_summary(
         ),
         "details": details,
     }
-
-
-def fetch_repo_actions_permissions(
-    client: BaseHttpClient,
-    owner: str,
-    repo: str,
-) -> dict[str, Any]:
-    """Return repo-level Actions permissions from the GitHub API."""
-    try:
-        data = client.get(f"/repos/{owner}/{repo}/actions/permissions")
-        return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
-
-
-def fetch_latest_workflow_run_created_at(
-    client: BaseHttpClient,
-    owner: str,
-    repo: str,
-) -> str | None:
-    """Return created_at of the most recent workflow run for a repo."""
-    try:
-        data = client.get(f"/repos/{owner}/{repo}/actions/runs?per_page=1")
-        if isinstance(data, dict):
-            runs = data.get("workflow_runs", [])
-            if runs:
-                first = runs[0]
-                if isinstance(first, dict):
-                    return first.get("created_at")
-        return None
-    except Exception:
-        return None
 
 
 def fetch_repo_file_text(
@@ -531,6 +501,52 @@ class WorkflowsEndpoint(BaseEndpoint):
             )
         except Exception:
             return WorkflowData()
+
+
+class RepoActionsPermissionsEndpoint(BaseEndpoint):
+    """Repository-level GitHub Actions permissions settings."""
+
+    @property
+    def name(self) -> str:
+        return "repo_actions_permissions"
+
+    def fetch(self, owner: str, repo: str) -> RepoActionsPermissionsData:
+        try:
+            data = self.client.get(f"/repos/{owner}/{repo}/actions/permissions")
+            if not isinstance(data, dict):
+                return RepoActionsPermissionsData()
+            return RepoActionsPermissionsData.model_validate(data)
+        except Exception:
+            return RepoActionsPermissionsData()
+
+
+class LatestWorkflowRunEndpoint(BaseEndpoint):
+    """Latest workflow run timestamp for a repository."""
+
+    @property
+    def name(self) -> str:
+        return "latest_workflow_run"
+
+    def fetch(
+        self,
+        owner: str,
+        repo: str,
+        workflows: WorkflowData | None = None,
+    ) -> LatestWorkflowRunData:
+        if workflows is not None and workflows.count == 0:
+            return LatestWorkflowRunData()
+
+        try:
+            data = self.client.get(f"/repos/{owner}/{repo}/actions/runs?per_page=1")
+            if isinstance(data, dict):
+                runs = data.get("workflow_runs", [])
+                if runs:
+                    first = runs[0]
+                    if isinstance(first, dict):
+                        return LatestWorkflowRunData(created_at=first.get("created_at"))
+            return LatestWorkflowRunData()
+        except Exception:
+            return LatestWorkflowRunData()
 
 
 class DependencyGraphEndpoint(BaseEndpoint):

--- a/core/models.py
+++ b/core/models.py
@@ -153,6 +153,21 @@ class WorkflowData(BaseModel):
     analysis: Optional[WorkflowAnalysis] = None
 
 
+class RepoActionsPermissionsData(BaseModel):
+    """Repository-level GitHub Actions permissions settings."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: Optional[bool] = None
+    allowed_actions: Optional[str] = None
+
+
+class LatestWorkflowRunData(BaseModel):
+    """Timestamp of the most recent workflow run for a repository."""
+
+    created_at: Optional[str] = None
+
+
 class WorkflowPermissionFinding(BaseModel):
     """Result of checking a single workflow file for permissions posture."""
 
@@ -334,6 +349,8 @@ class RepoData(BaseModel):
     community: Optional[CommunityProfile] = None
     codeowners: Optional[CodeownersData] = None
     workflows: Optional[WorkflowData] = None
+    repo_actions_permissions: Optional[RepoActionsPermissionsData] = None
+    latest_workflow_run: Optional[LatestWorkflowRunData] = None
     fork_template: Optional[ForkTemplateData] = None
     dependency_graph: Optional[DependencyGraphData] = None
     repo_tree: Optional[RepoTreeData] = None

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -80,8 +80,8 @@ def build_repo_row(
         sorted(wf.get("name", "") for wf in (workflows.workflows if workflows else []))
     )
 
-    actions_enabled = actions_permissions.get("enabled")
-    allowed_actions = actions_permissions.get("allowed_actions", "")
+    actions_enabled = actions_permissions.enabled
+    allowed_actions = actions_permissions.allowed_actions or ""
 
     if archived and has_workflows:
         posture = "archived_with_workflows"
@@ -303,10 +303,10 @@ def main() -> None:
     print(f"Found {len(repo_list)} repositories to scan.", file=sys.stderr)
 
     # ================================================================
-    # Stage 2: Collect baseline repo metadata and workflow posture data
+    # Stage 2: Collect baseline repo metadata and workflow inventory
     # ================================================================
 
-    # 2. Collect repo details + workflow posture data via core
+    # 2. Collect repo details + workflow inventory via core
     storage = SqliteRepoStorage(args.db)
     collector = RepoCollector(
         storage=storage,
@@ -314,18 +314,46 @@ def main() -> None:
         endpoints=[
             RepoDetailsEndpoint,
             WorkflowsEndpoint,
-            RepoActionsPermissionsEndpoint,
-            LatestWorkflowRunEndpoint,
         ],
     )
     primary_org = repo_list[0].split("/", 1)[0]
     collector.collect(primary_org, repos=repo_list, resume=args.resume)
 
     # ================================================================
-    # Stage 3: Read collected data and build output row sets
+    # Stage 3: Collect remaining workflow posture data
     # ================================================================
 
-    # 3. Read collected data and build output rows
+    # 3.1 Collect repo-level Actions permissions for all repos
+    collector = RepoCollector(
+        storage=storage,
+        client=client,
+        endpoints=[RepoActionsPermissionsEndpoint],
+    )
+    collector.collect(primary_org, repos=repo_list, resume=args.resume)
+
+    # 3.2 Collect latest workflow run only for repos that have workflows
+    repos_with_workflows: List[str] = []
+    for full_name in repo_list:
+        data = storage.read(full_name) or RepoData()
+        if data.workflows and data.workflows.count > 0:
+            repos_with_workflows.append(full_name)
+    if repos_with_workflows:
+        collector = RepoCollector(
+            storage=storage,
+            client=client,
+            endpoints=[LatestWorkflowRunEndpoint],
+        )
+        collector.collect(
+            primary_org,
+            repos=repos_with_workflows,
+            resume=args.resume,
+        )
+
+    # ================================================================
+    # Stage 4: Read collected data and build output row sets
+    # ================================================================
+
+    # 4. Read collected data and build output rows
     repo_rows: List[Dict[str, Any]] = []
     detail_rows: List[Dict[str, Any]] = []
     total = len(repo_list)
@@ -337,10 +365,10 @@ def main() -> None:
         detail_rows.extend(build_workflow_detail_rows(full_name, data))
 
     # ================================================================
-    # Stage 4: Write repo-level posture reports
+    # Stage 5: Write repo-level posture reports
     # ================================================================
 
-    # 4. Write posture outputs
+    # 5. Write posture outputs
     prefix = args.out_prefix
     repo_count = CsvCompiler.write_rows(f"{prefix}_repo_summary.csv", repo_rows)
     details_count = CsvCompiler.write_rows(
@@ -358,10 +386,10 @@ def main() -> None:
     )
 
     # ================================================================
-    # Stage 5: Parse workflow files to inventory action usage
+    # Stage 6: Parse workflow files to inventory action usage
     # ================================================================
 
-    # 5. Analyse most common GitHub Actions used
+    # 6. Analyse most common GitHub Actions used
     print("\n--- Analysing actions used across workflows ---")
 
     all_actions: List[Dict[str, Any]] = []
@@ -405,10 +433,10 @@ def main() -> None:
     print(f"Unique owners: {len(owner_summary)}")
 
     # ================================================================
-    # Stage 6: Parse workflow files for permissions posture
+    # Stage 7: Parse workflow files for permissions posture
     # ================================================================
 
-    # 6. Workflow permissions check
+    # 7. Workflow permissions check
     print("\n--- Analysing workflow permissions ---")
 
     all_permissions: List[Dict[str, Any]] = []

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -4,11 +4,9 @@
 Refactored to use core modules:
   - Repo discovery / loading     core.github_api.list_org_repos, core.repo_list
   - HTTP transport               core.github_client.GitHubHttpClient
-  - Workflow + repo data         WorkflowsEndpoint + RepoDetailsEndpoint via RepoCollector
+    - Workflow + repo data         RepoCollector with typed repo-scoped endpoints
 
 Not yet in core (local implementations retained):
-  - Repo-level Actions permissions  GET /repos/{owner}/{repo}/actions/permissions
-  - Latest workflow run timestamp   GET /repos/{owner}/{repo}/actions/runs
   - Workflow YAML uses: parsing
 """
 
@@ -18,21 +16,21 @@ import sys
 import time
 from collections import Counter
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from core.collector import RepoCollector
 from core.compiler import CsvCompiler
 from core.github_api import (
+    LatestWorkflowRunEndpoint,
     RepoDetailsEndpoint,
+    RepoActionsPermissionsEndpoint,
     WorkflowsEndpoint,
     check_workflow_permissions,
-    fetch_latest_workflow_run_created_at,
-    fetch_repo_actions_permissions,
     fetch_repo_file_text,
     list_org_repos,
 )
 from core.github_client import GitHubHttpClient
-from core.models import RepoData
+from core.models import RepoActionsPermissionsData, RepoData
 from core.repo_list import load_repo_list_file
 from core.storage import SqliteRepoStorage
 from core.transforms import parse_actions_from_content
@@ -65,12 +63,11 @@ def parse_actions_from_workflow(
 def build_repo_row(
     full_name: str,
     data: RepoData,
-    actions_permissions: Dict[str, Any],
-    latest_run_date: Optional[str],
 ) -> Dict[str, Any]:
-    """Build a posture summary row from RepoData and locally fetched supplements."""
+    """Build a posture summary row from collected RepoData."""
     repo = data.repo_details
     workflows = data.workflows
+    actions_permissions = data.repo_actions_permissions or RepoActionsPermissionsData()
     owner, _, repo_name = full_name.partition("/")
 
     archived = repo.archived if repo else False
@@ -111,7 +108,10 @@ def build_repo_row(
         "has_workflows": has_workflows,
         "workflow_count": workflow_count,
         "workflow_names": workflow_names,
-        "latest_workflow_run": latest_run_date or "",
+        "latest_workflow_run": (
+            data.latest_workflow_run.created_at if data.latest_workflow_run else ""
+        )
+        or "",
         "posture": posture,
         "disable_candidate": disable_candidate,
     }
@@ -303,42 +303,37 @@ def main() -> None:
     print(f"Found {len(repo_list)} repositories to scan.", file=sys.stderr)
 
     # ================================================================
-    # Stage 2: Collect baseline repo metadata and workflow inventory
+    # Stage 2: Collect baseline repo metadata and workflow posture data
     # ================================================================
 
-    # 2. Collect repo details + workflow inventory via core
+    # 2. Collect repo details + workflow posture data via core
     storage = SqliteRepoStorage(args.db)
     collector = RepoCollector(
         storage=storage,
         client=client,
-        endpoints=[RepoDetailsEndpoint, WorkflowsEndpoint],
+        endpoints=[
+            RepoDetailsEndpoint,
+            WorkflowsEndpoint,
+            RepoActionsPermissionsEndpoint,
+            LatestWorkflowRunEndpoint,
+        ],
     )
     primary_org = repo_list[0].split("/", 1)[0]
     collector.collect(primary_org, repos=repo_list, resume=args.resume)
 
     # ================================================================
-    # Stage 3: Enrich collected data and build output row sets
+    # Stage 3: Read collected data and build output row sets
     # ================================================================
 
-    # 3. Augment with local-only endpoints and build output rows
+    # 3. Read collected data and build output rows
     repo_rows: List[Dict[str, Any]] = []
     detail_rows: List[Dict[str, Any]] = []
     total = len(repo_list)
     for idx, full_name in enumerate(repo_list, start=1):
-        owner, _, repo_name = full_name.partition("/")
         print(f"[{idx}/{total}] Augmenting {full_name}...", file=sys.stderr)
 
         data = storage.read(full_name) or RepoData()
-        actions_permissions = fetch_repo_actions_permissions(client, owner, repo_name)
-        latest_run = (
-            fetch_latest_workflow_run_created_at(client, owner, repo_name)
-            if data.workflows and data.workflows.count > 0
-            else None
-        )
-
-        repo_rows.append(
-            build_repo_row(full_name, data, actions_permissions, latest_run)
-        )
+        repo_rows.append(build_repo_row(full_name, data))
         detail_rows.extend(build_workflow_detail_rows(full_name, data))
 
     # ================================================================

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -274,6 +274,10 @@ def main() -> None:
 
     client = GitHubHttpClient()
 
+    # ================================================================
+    # Stage 1: Resolve the repository list to scan
+    # ================================================================
+
     # 1. Resolve repo list
     if args.repos:
         repo_list = args.repos[: args.limit]
@@ -293,6 +297,10 @@ def main() -> None:
         raise SystemExit("No repositories found to scan.")
     print(f"Found {len(repo_list)} repositories to scan.", file=sys.stderr)
 
+    # ================================================================
+    # Stage 2: Collect baseline repo metadata and workflow inventory
+    # ================================================================
+
     # 2. Collect repo details + workflow inventory via core
     storage = SqliteRepoStorage(args.db)
     collector = RepoCollector(
@@ -302,6 +310,10 @@ def main() -> None:
     )
     primary_org = repo_list[0].split("/", 1)[0]
     collector.collect(primary_org, repos=repo_list, resume=False)
+
+    # ================================================================
+    # Stage 3: Enrich collected data and build output row sets
+    # ================================================================
 
     # 3. Augment with local-only endpoints and build output rows
     repo_rows: List[Dict[str, Any]] = []
@@ -324,6 +336,10 @@ def main() -> None:
         )
         detail_rows.extend(build_workflow_detail_rows(full_name, data))
 
+    # ================================================================
+    # Stage 4: Write repo-level posture reports
+    # ================================================================
+
     # 4. Write posture outputs
     prefix = args.out_prefix
     repo_count = CsvCompiler.write_rows(f"{prefix}_repo_summary.csv", repo_rows)
@@ -340,6 +356,10 @@ def main() -> None:
         f"with {len(detail_rows)} total workflow files.",
         file=sys.stderr,
     )
+
+    # ================================================================
+    # Stage 5: Parse workflow files to inventory action usage
+    # ================================================================
 
     # 5. Analyse most common GitHub Actions used
     print("\n--- Analysing actions used across workflows ---")
@@ -383,6 +403,10 @@ def main() -> None:
 
     print(f"Unique actions: {len(usage_summary)}")
     print(f"Unique owners: {len(owner_summary)}")
+
+    # ================================================================
+    # Stage 6: Parse workflow files for permissions posture
+    # ================================================================
 
     # 6. Workflow permissions check
     print("\n--- Analysing workflow permissions ---")

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -270,6 +270,11 @@ def main() -> None:
         default=DEFAULT_DB,
         help=f"SQLite path for collection cache (default: {DEFAULT_DB})",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume collection by skipping endpoint data already cached in the database",
+    )
     args = parser.parse_args()
 
     client = GitHubHttpClient()
@@ -309,7 +314,7 @@ def main() -> None:
         endpoints=[RepoDetailsEndpoint, WorkflowsEndpoint],
     )
     primary_org = repo_list[0].split("/", 1)[0]
-    collector.collect(primary_org, repos=repo_list, resume=False)
+    collector.collect(primary_org, repos=repo_list, resume=args.resume)
 
     # ================================================================
     # Stage 3: Enrich collected data and build output row sets

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -18,15 +18,15 @@ from core.github_api import (
     DependencyGraphEndpoint,
     ForkTemplateEndpoint,
     GetRepoTreeEndpoint,
+    LatestWorkflowRunEndpoint,
     OrgActionsEndpoint,
     OrgMembersEndpoint,
     OrgRulesetsEndpoint,
     OrgWebhooksEndpoint,
+    RepoActionsPermissionsEndpoint,
     RepoDetailsEndpoint,
     WorkflowsEndpoint,
     dependency_supply_chain_summary,
-    fetch_latest_workflow_run_created_at,
-    fetch_repo_actions_permissions,
     fetch_repo_alerts,
     fetch_repo_file_text,
     list_org_repos,
@@ -39,11 +39,13 @@ from core.models import (
     CommunityProfile,
     DependencyGraphData,
     ForkTemplateData,
+    LatestWorkflowRunData,
     OrgActionsData,
     OrgMembersData,
     OrgRulesetsData,
     OrgWebhooksData,
     ReferenceData,
+    RepoActionsPermissionsData,
     RepoDetails,
     RepoTreeData,
     WorkflowData,
@@ -157,7 +159,7 @@ class TestDependencySupplyChainSummary:
 
 
 class TestWorkflowAndAlertHelpers:
-    def test_fetch_repo_actions_permissions(self):
+    def test_repo_actions_permissions_endpoint(self):
         client = MockHttpClient(
             {
                 "/repos/o/r/actions/permissions": {
@@ -166,10 +168,18 @@ class TestWorkflowAndAlertHelpers:
                 }
             }
         )
-        result = fetch_repo_actions_permissions(client, "o", "r")
-        assert result["enabled"] is True
+        result = RepoActionsPermissionsEndpoint(client).fetch("o", "r")
+        assert isinstance(result, RepoActionsPermissionsData)
+        assert result.enabled is True
+        assert result.allowed_actions == "selected"
 
-    def test_fetch_latest_workflow_run_created_at(self):
+    def test_repo_actions_permissions_endpoint_error_returns_default(self):
+        client = MockHttpClient()
+        result = RepoActionsPermissionsEndpoint(client).fetch("o", "r")
+        assert isinstance(result, RepoActionsPermissionsData)
+        assert result.enabled is None
+
+    def test_latest_workflow_run_endpoint(self):
         client = MockHttpClient(
             {
                 "/repos/o/r/actions/runs?per_page=1": {
@@ -177,15 +187,28 @@ class TestWorkflowAndAlertHelpers:
                 }
             }
         )
-        result = fetch_latest_workflow_run_created_at(client, "o", "r")
-        assert result == "2026-01-01T10:00:00Z"
+        result = LatestWorkflowRunEndpoint(client).fetch(
+            "o", "r", workflows=WorkflowData(count=1)
+        )
+        assert isinstance(result, LatestWorkflowRunData)
+        assert result.created_at == "2026-01-01T10:00:00Z"
 
-    def test_fetch_latest_workflow_run_created_at_missing(self):
+    def test_latest_workflow_run_endpoint_missing(self):
         client = MockHttpClient(
             {"/repos/o/r/actions/runs?per_page=1": {"workflow_runs": []}}
         )
-        result = fetch_latest_workflow_run_created_at(client, "o", "r")
-        assert result is None
+        result = LatestWorkflowRunEndpoint(client).fetch(
+            "o", "r", workflows=WorkflowData(count=1)
+        )
+        assert result.created_at is None
+
+    def test_latest_workflow_run_endpoint_skips_api_when_no_workflows(self):
+        client = MockHttpClient()
+        result = LatestWorkflowRunEndpoint(client).fetch(
+            "o", "r", workflows=WorkflowData(count=0)
+        )
+        assert result.created_at is None
+        assert client.calls == []
 
     def test_fetch_repo_file_text(self):
         client = MockHttpClient(


### PR DESCRIPTION
This pull request refactors the way repository-level GitHub Actions permissions and the latest workflow run timestamp are collected and handled. Instead of using ad-hoc helper functions, these data points are now collected using new, typed endpoint classes integrated with the `RepoCollector` system. The changes also update the data models and workflow to support this improved collection process, and update tests accordingly.

**Enhancements to data collection and models:**

* Introduced new endpoint classes `RepoActionsPermissionsEndpoint` and `LatestWorkflowRunEndpoint` for fetching repository-level Actions permissions and the latest workflow run timestamp, respectively, and integrated them with the `RepoCollector` workflow. [[1]](diffhunk://#diff-1ef183d30706cae2f822028d53062297a64bbc725954b6c587312806b175e8e5R506-R551) [[2]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1L21-R33) [[3]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1R305-R371)
* Added new data models `RepoActionsPermissionsData` and `LatestWorkflowRunData` to `core/models.py`, and included them as fields in `RepoData`. [[1]](diffhunk://#diff-880083c8a05dc4662af880cde1cf569e18f4476182e8680d2cee4cf1281a3d6eR156-R170) [[2]](diffhunk://#diff-880083c8a05dc4662af880cde1cf569e18f4476182e8680d2cee4cf1281a3d6eR352-R353)
* Removed the old helper functions `fetch_repo_actions_permissions` and `fetch_latest_workflow_run_created_at`, updating all references to use the new endpoint-based approach. [[1]](diffhunk://#diff-1ef183d30706cae2f822028d53062297a64bbc725954b6c587312806b175e8e5L166-L197) [[2]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1L21-R33) [[3]](diffhunk://#diff-f889290dec878f09fce75213b98b98a68f7619e27c6fb020d5ef0e5df3079e09R21-L29)

**Workflow and CLI improvements:**

* Updated the main workflow in `github_workflow.py` to collect Actions permissions and latest workflow run data in dedicated stages, only querying the latest run for repositories with workflows. Added a `--resume` flag to allow resuming collection using cached data. [[1]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1R273-R285) [[2]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1R305-R371)
* Simplified the `build_repo_row` function to use the new data model fields, improving code clarity and maintainability. [[1]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1L68-R70) [[2]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1L86-R84) [[3]](diffhunk://#diff-b8aa8854667f3c96b4f164a5d2593890531973f80bfa44fca81efdefb95d72b1L114-R114)

**Testing improvements:**

* Refactored and expanded tests in `tests/test_github_api.py` to cover the new endpoints and data models, including error handling and edge cases. [[1]](diffhunk://#diff-f889290dec878f09fce75213b98b98a68f7619e27c6fb020d5ef0e5df3079e09L160-R162) [[2]](diffhunk://#diff-f889290dec878f09fce75213b98b98a68f7619e27c6fb020d5ef0e5df3079e09L169-R211)