### PR TITLE
feat: add SHA pinning compliance check

### DIFF
--- a/core/transforms.py
+++ b/core/transforms.py
@@ -334,6 +334,11 @@ def parse_workflow_permissions(content: str) -> dict[str, object]:
     }
 
 
+def is_pinned_to_sha(version: str) -> bool:
+    """Check if a version string is a full 40-character commit SHA."""
+    return bool(re.match(r"^[0-9a-f]{40}$", version))
+
+
 def parse_actions_from_content(
     content: str, repo_name: str, workflow_path: str
 ) -> list[dict[str, str]]:
@@ -362,6 +367,12 @@ def parse_actions_from_content(
                         "owner": action_name.split("/")[0]
                         if "/" in action_name
                         else action_name,
+                        "is_pinned": is_pinned_to_sha(version),
+                        "pin_type": "sha"
+                        if is_pinned_to_sha(version)
+                        else "none"
+                        if version == "none"
+                        else "mutable_tag",
                     }
                 )
     return actions

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -432,6 +432,63 @@ def main() -> None:
     print(f"Unique actions: {len(usage_summary)}")
     print(f"Unique owners: {len(owner_summary)}")
 
+    # 6b. SHA pinning compliance
+    print("\n--- Analysing SHA pinning compliance ---")
+
+    unpinned_actions = [
+        a for a in all_actions if not a["is_pinned"] and a["version"] != "none"
+    ]
+    pinned_actions = [a for a in all_actions if a["is_pinned"]]
+
+    print(f"Total action references: {len(all_actions)}")
+    print(f"Pinned to SHA: {len(pinned_actions)}")
+    print(f"Unpinned (mutable tag): {len(unpinned_actions)}")
+
+    unpinned_count = CsvCompiler.write_rows(
+        "github_actions_unpinned_detail.csv", unpinned_actions
+    )
+    print(f"Wrote github_actions_unpinned_detail.csv ({unpinned_count} rows)")
+
+    repo_pinning: Dict[str, Dict[str, int]] = {}
+    for a in all_actions:
+        if a["version"] == "none":
+            continue
+        repo = a["repo"]
+        if repo not in repo_pinning:
+            repo_pinning[repo] = {"total": 0, "pinned": 0, "unpinned": 0}
+        repo_pinning[repo]["total"] += 1
+        if a["is_pinned"]:
+            repo_pinning[repo]["pinned"] += 1
+        else:
+            repo_pinning[repo]["unpinned"] += 1
+
+    pinning_summary = [
+        {
+            "repo": repo,
+            "total_refs": counts["total"],
+            "pinned": counts["pinned"],
+            "unpinned": counts["unpinned"],
+            "compliance_pct": round(
+                counts["pinned"] / max(counts["total"], 1) * 100, 1
+            ),
+        }
+        for repo, counts in sorted(
+            repo_pinning.items(), key=lambda x: x[1]["unpinned"], reverse=True
+        )
+    ]
+
+    pinning_count = CsvCompiler.write_rows(
+        "github_actions_pinning_per_repo.csv", pinning_summary
+    )
+    print(f"Wrote github_actions_pinning_per_repo.csv ({pinning_count} rows)")
+    print(
+        f"Repos with unpinned actions: "
+        f"{sum(1 for s in pinning_summary if s['unpinned'] > 0)}"
+    )
+    print(
+        f"Repos fully pinned: {sum(1 for s in pinning_summary if s['unpinned'] == 0)}"
+    )
+
     # ================================================================
     # Stage 7: Parse workflow files for permissions posture
     # ================================================================

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -25,6 +25,7 @@ from core.transforms import (
     TimestampTransform,
     parse_workflow_permissions,
     parse_actions_from_content,
+    is_pinned_to_sha,
 )
 
 
@@ -472,3 +473,125 @@ class TestParseActionsFromContent:
     def test_empty_content(self) -> None:
         result = parse_actions_from_content("", "r", "ci.yml")
         assert result == []
+
+
+class TestIsPinnedToSha:
+    def test_valid_sha_returns_true(self):
+        sha = "a12a3943b11318369cde8d083ae4d22002f08cba"
+        assert is_pinned_to_sha(sha) is True
+
+    def test_short_sha_returns_false(self):
+        assert is_pinned_to_sha("a12a394") is False
+
+    def test_mutable_tag_v3_returns_false(self):
+        assert is_pinned_to_sha("v3") is False
+
+    def test_main_branch_returns_false(self):
+        assert is_pinned_to_sha("main") is False
+
+    def test_master_branch_returns_false(self):
+        assert is_pinned_to_sha("master") is False
+
+    def test_semver_tag_returns_false(self):
+        assert is_pinned_to_sha("v1.8.1") is False
+
+    def test_uppercase_hex_returns_false(self):
+        sha = "A12A3943B11318369CDE8D083AE4D22002F08CBA"
+        assert is_pinned_to_sha(sha) is False
+
+    def test_empty_string_returns_false(self):
+        assert is_pinned_to_sha("") is False
+
+    def test_none_string_returns_false(self):
+        assert is_pinned_to_sha("none") is False
+
+
+class TestParseActionsFromContentPinning:
+    def test_pinned_action_has_correct_fields(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@a12a3943b11318369cde8d083ae4d22002f08cba\n"
+        )
+        result = parse_actions_from_content(
+            content, "my-repo", ".github/workflows/ci.yml"
+        )
+        assert len(result) == 1
+        assert result[0]["is_pinned"] is True
+        assert result[0]["pin_type"] == "sha"
+        assert result[0]["action_name"] == "actions/checkout"
+        assert result[0]["owner"] == "actions"
+
+    def test_unpinned_action_mutable_tag(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v3\n"
+        )
+        result = parse_actions_from_content(
+            content, "my-repo", ".github/workflows/ci.yml"
+        )
+        assert len(result) == 1
+        assert result[0]["is_pinned"] is False
+        assert result[0]["pin_type"] == "mutable_tag"
+
+    def test_main_branch_is_unpinned(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@main\n"
+        )
+        result = parse_actions_from_content(
+            content, "my-repo", ".github/workflows/ci.yml"
+        )
+        assert result[0]["is_pinned"] is False
+        assert result[0]["pin_type"] == "mutable_tag"
+
+    def test_mixed_pinned_and_unpinned(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@a12a3943b11318369cde8d083ae4d22002f08cba\n"
+            "      - uses: actions/setup-node@v4\n"
+        )
+        result = parse_actions_from_content(
+            content, "my-repo", ".github/workflows/ci.yml"
+        )
+        assert len(result) == 2
+        assert result[0]["is_pinned"] is True
+        assert result[0]["pin_type"] == "sha"
+        assert result[1]["is_pinned"] is False
+        assert result[1]["pin_type"] == "mutable_tag"
+
+    def test_semver_tag_is_unpinned(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1\n"
+        )
+        result = parse_actions_from_content(
+            content, "my-repo", ".github/workflows/ci.yml"
+        )
+        assert result[0]["is_pinned"] is False
+        assert result[0]["pin_type"] == "mutable_tag"
+        assert result[0]["owner"] == "aws-actions"


### PR DESCRIPTION
# Introduction :pencil2:

Adds SHA pinning compliance analysis to the workflow posture scanner (ticket #29). Extends the existing actions parsing to flag whether each `uses:` reference is pinned to a full 40-character commit SHA or uses a mutable tag (e.g. `@v3`, `@main`).

## Resolution :heavy_check_mark:

- `core/transforms.py`: Added `is_pinned_to_sha()` pure function — checks if a version string is a 40-char hex SHA. Extended `parse_actions_from_content()` output dict with `is_pinned` (bool) and `pin_type` (`sha`, `mutable_tag`, `none`) fields.
- `github_workflow.py`: Added SHA pinning compliance analysis stage in `main()` — filters pinned vs unpinned actions, builds per-repo summary with compliance percentage. Outputs `github_actions_unpinned_detail.csv` and `github_actions_pinning_per_repo.csv` via `CsvCompiler`.
- `tests/test_transforms.py`: Added 14 new tests across `TestIsPinnedToSha` (9 tests) and `TestParseActionsFromContentPinning` (5 tests). All 55 tests passing.

## Miscellaneous :heavy_plus_sign:

- No new dependencies required
- Follows existing architecture: pure transform logic in `core/transforms.py`, orchestration in `main()`, output via `CsvCompiler`
- Note: `core/compiler.py` line 184 has a pre-existing syntax bug (`except KeyError; TypeError:` should be `except (KeyError, TypeError):`) — not fixed in this PR, flagged separately


</details>

Closes #29