### PR TITLE
feat: assess OIDC vs long-lived credentials

### DIFF
--- a/core/github_api.py
+++ b/core/github_api.py
@@ -34,13 +34,14 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from core.transforms import parse_workflow_permissions
+from core.transforms import parse_workflow_permissions, assess_credential_posture
 
 from core.github_client import BaseHttpClient
 from core.models import (
     AlertData,
     BranchProtection,
     CodeownersData,
+    CredentialPostureFinding,
     CommunityProfile,
     DependencyGraphData,
     ForkTemplateData,
@@ -201,6 +202,29 @@ def check_workflow_permissions(
 
     parsed = parse_workflow_permissions(content)
     return WorkflowPermissionFinding(
+        repo=f"{owner}/{repo_name}",
+        workflow_path=workflow_path,
+        **parsed,
+    )
+
+
+def check_credential_posture(
+    client: BaseHttpClient,
+    owner: str,
+    repo_name: str,
+    workflow_path: str,
+) -> CredentialPostureFinding:
+    """Check if a workflow uses OIDC or long-lived credentials."""
+    content = fetch_repo_file_text(client, owner, repo_name, workflow_path)
+    if content is None:
+        return CredentialPostureFinding(
+            repo=f"{owner}/{repo_name}",
+            workflow_path=workflow_path,
+            posture="could_not_load",
+        )
+
+    parsed = assess_credential_posture(content)
+    return CredentialPostureFinding(
         repo=f"{owner}/{repo_name}",
         workflow_path=workflow_path,
         **parsed,

--- a/core/github_api.py
+++ b/core/github_api.py
@@ -34,7 +34,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from core.transforms import parse_workflow_permissions, assess_credential_posture
+from core.transforms import parse_workflow_permissions, CredentialPostureTransform
 
 from core.github_client import BaseHttpClient
 from core.models import (
@@ -223,7 +223,7 @@ def check_credential_posture(
             posture="could_not_load",
         )
 
-    parsed = assess_credential_posture(content)
+    parsed = CredentialPostureTransform.assess_credential_posture(content)
     return CredentialPostureFinding(
         repo=f"{owner}/{repo_name}",
         workflow_path=workflow_path,

--- a/core/models.py
+++ b/core/models.py
@@ -179,6 +179,17 @@ class WorkflowPermissionFinding(BaseModel):
     finding: str = "no_permissions_block"
 
 
+class CredentialPostureFinding(BaseModel):
+    """Result of checking a single workflow file for OIDC vs long-lived credentials."""
+
+    repo: str
+    workflow_path: str
+    has_id_token_write: bool = False
+    oidc_actions: str = ""
+    credential_secrets_found: str = ""
+    posture: str = "no_cloud_auth_detected"
+
+
 class ForkTemplateData(BaseModel):
     """Fork origin and template source details."""
 

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -19,7 +19,7 @@ mutating the model in place.  Pydantic models are designed for this pattern.
 """
 
 from __future__ import annotations
-
+from typing import Any
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 import re
@@ -331,6 +331,69 @@ def parse_workflow_permissions(content: str) -> dict[str, object]:
         "permissions_value": permissions_value,
         "has_write_permissions": has_write,
         "finding": finding,
+    }
+
+
+def assess_credential_posture(content: str) -> dict[str, Any]:
+    """Parse workflow content for OIDC indicators and long-lived credential patterns."""
+
+    OIDC_ACTION_PREFIXES = (
+        "aws-actions/configure-aws-credentials",
+        "azure/login",
+        "google-github-actions/auth",
+    )
+
+    CREDENTIAL_SECRET_PATTERNS = (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_ACCESS_KEY",
+        "AWS_SECRET_KEY",
+        "AWS_SESSION_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CREDENTIALS",
+        "GCP_SA_KEY",
+        "GCP_CREDENTIALS",
+    )
+
+    has_id_token_write = False
+    oidc_actions: list[str] = []
+    credential_secrets_found: list[str] = []
+
+    for line in content.splitlines():
+        stripped = line.strip()
+
+        if stripped.startswith("id-token") and "write" in stripped:
+            has_id_token_write = True
+
+        if stripped.startswith("- uses:") or stripped.startswith("uses:"):
+            for prefix in OIDC_ACTION_PREFIXES:
+                if prefix in stripped:
+                    oidc_actions.append(prefix)
+
+        for pattern in CREDENTIAL_SECRET_PATTERNS:
+            if pattern in stripped and "secrets." in stripped.lower():
+                if pattern not in credential_secrets_found:
+                    credential_secrets_found.append(pattern)
+
+    has_oidc = has_id_token_write or len(oidc_actions) > 0
+    has_long_lived = len(credential_secrets_found) > 0
+
+    if has_oidc and has_long_lived:
+        posture = "mixed"
+    elif has_oidc:
+        posture = "oidc"
+    elif has_long_lived:
+        posture = "long_lived_credentials"
+    else:
+        posture = "no_cloud_auth_detected"
+
+    return {
+        "has_id_token_write": has_id_token_write,
+        "oidc_actions": "; ".join(oidc_actions) if oidc_actions else "",
+        "credential_secrets_found": "; ".join(credential_secrets_found)
+        if credential_secrets_found
+        else "",
+        "posture": posture,
     }
 
 

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -278,6 +278,81 @@ class RepoTreeTransform(BaseTransform):
         return data.model_copy(update={"repo_tree_transform": processed})
 
 
+class CredentialPostureTransform(BaseTransform):
+    """Assess workflow content for OIDC indicators and long-lived credential patterns."""
+
+    OIDC_ACTION_PREFIXES = (
+        "aws-actions/configure-aws-credentials",
+        "azure/login",
+        "google-github-actions/auth",
+    )
+
+    CREDENTIAL_SECRET_PATTERNS = (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_ACCESS_KEY",
+        "AWS_SECRET_KEY",
+        "AWS_SESSION_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CREDENTIALS",
+        "GCP_SA_KEY",
+        "GCP_CREDENTIALS",
+    )
+
+    @property
+    def name(self) -> str:
+        return "credential_posture"
+
+    @staticmethod
+    def assess_credential_posture(content: str) -> dict[str, Any]:
+        """Parse workflow content for OIDC indicators and long-lived credential patterns."""
+
+        has_id_token_write = False
+        oidc_actions: list[str] = []
+        credential_secrets_found: list[str] = []
+
+        for line in content.splitlines():
+            stripped = line.strip()
+
+            if stripped.startswith("id-token") and "write" in stripped:
+                has_id_token_write = True
+
+            if stripped.startswith("- uses:") or stripped.startswith("uses:"):
+                for prefix in CredentialPostureTransform.OIDC_ACTION_PREFIXES:
+                    if prefix in stripped:
+                        oidc_actions.append(prefix)
+
+            for pattern in CredentialPostureTransform.CREDENTIAL_SECRET_PATTERNS:
+                if pattern in stripped and "secrets." in stripped.lower():
+                    if pattern not in credential_secrets_found:
+                        credential_secrets_found.append(pattern)
+
+        has_oidc = has_id_token_write or len(oidc_actions) > 0
+        has_long_lived = len(credential_secrets_found) > 0
+
+        if has_oidc and has_long_lived:
+            posture = "mixed"
+        elif has_oidc:
+            posture = "oidc"
+        elif has_long_lived:
+            posture = "long_lived_credentials"
+        else:
+            posture = "no_cloud_auth_detected"
+
+        return {
+            "has_id_token_write": has_id_token_write,
+            "oidc_actions": "; ".join(oidc_actions) if oidc_actions else "",
+            "credential_secrets_found": "; ".join(credential_secrets_found)
+            if credential_secrets_found
+            else "",
+            "posture": posture,
+        }
+
+    def apply(self, data: RepoData) -> RepoData:
+        """No-op at repo level — credential posture is assessed per-workflow in Stage 8."""
+        return data
+
+
 # — Standalone parsing helpers ————————————————————————
 
 
@@ -334,69 +409,6 @@ def parse_workflow_permissions(content: str) -> dict[str, object]:
     }
 
 
-def assess_credential_posture(content: str) -> dict[str, Any]:
-    """Parse workflow content for OIDC indicators and long-lived credential patterns."""
-
-    OIDC_ACTION_PREFIXES = (
-        "aws-actions/configure-aws-credentials",
-        "azure/login",
-        "google-github-actions/auth",
-    )
-
-    CREDENTIAL_SECRET_PATTERNS = (
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_ACCESS_KEY",
-        "AWS_SECRET_KEY",
-        "AWS_SESSION_TOKEN",
-        "AZURE_CLIENT_SECRET",
-        "AZURE_CREDENTIALS",
-        "GCP_SA_KEY",
-        "GCP_CREDENTIALS",
-    )
-
-    has_id_token_write = False
-    oidc_actions: list[str] = []
-    credential_secrets_found: list[str] = []
-
-    for line in content.splitlines():
-        stripped = line.strip()
-
-        if stripped.startswith("id-token") and "write" in stripped:
-            has_id_token_write = True
-
-        if stripped.startswith("- uses:") or stripped.startswith("uses:"):
-            for prefix in OIDC_ACTION_PREFIXES:
-                if prefix in stripped:
-                    oidc_actions.append(prefix)
-
-        for pattern in CREDENTIAL_SECRET_PATTERNS:
-            if pattern in stripped and "secrets." in stripped.lower():
-                if pattern not in credential_secrets_found:
-                    credential_secrets_found.append(pattern)
-
-    has_oidc = has_id_token_write or len(oidc_actions) > 0
-    has_long_lived = len(credential_secrets_found) > 0
-
-    if has_oidc and has_long_lived:
-        posture = "mixed"
-    elif has_oidc:
-        posture = "oidc"
-    elif has_long_lived:
-        posture = "long_lived_credentials"
-    else:
-        posture = "no_cloud_auth_detected"
-
-    return {
-        "has_id_token_write": has_id_token_write,
-        "oidc_actions": "; ".join(oidc_actions) if oidc_actions else "",
-        "credential_secrets_found": "; ".join(credential_secrets_found)
-        if credential_secrets_found
-        else "",
-        "posture": posture,
-    }
-
-
 def is_pinned_to_sha(version: str) -> bool:
     """Check if a version string is a full 40-character commit SHA."""
     return bool(re.match(r"^[0-9a-f]{40}$", version))
@@ -450,4 +462,5 @@ TRANSFORMS: list[type[BaseTransform]] = [
     TimestampTransform,
     ReferenceClassifier,
     FlagTransform,
+    CredentialPostureTransform,
 ]

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -26,6 +26,7 @@ from core.github_api import (
     RepoActionsPermissionsEndpoint,
     WorkflowsEndpoint,
     check_workflow_permissions,
+    check_credential_posture,
     fetch_repo_file_text,
     list_org_repos,
 )
@@ -523,6 +524,87 @@ def main() -> None:
     print(f"permissions: write-all: {write_all}")
     print(f"Has write scope: {has_write_count}")
     print(f"Compliant (read-only): {compliant_count}")
+    print(f"Could not load: {skipped}")
+
+    # ================================================================
+    # Stage 8: Assess OIDC vs long-lived credentials
+    # ================================================================
+
+    # 8. OIDC vs long-lived credentials assessment
+    print("\n--- Assessing OIDC vs long-lived credentials ---")
+
+    all_credential_findings: List[Dict[str, Any]] = []
+    for i, row in enumerate(detail_rows):
+        finding = check_credential_posture(
+            client, row["owner"], row["repo_name"], row["path"]
+        )
+        all_credential_findings.append(finding.model_dump())
+
+        if (i + 1) % 100 == 0:
+            print(f" Checked {i + 1} / {len(detail_rows)} workflow files")
+            time.sleep(0.1)
+
+    cred_count = CsvCompiler.write_rows(
+        "github_workflow_credential_posture.csv", all_credential_findings
+    )
+    print(f"Wrote github_workflow_credential_posture.csv ({cred_count} rows)")
+
+    repo_cred_summary: Dict[str, Dict[str, int]] = {}
+    for f in all_credential_findings:
+        repo = f["repo"]
+        if repo not in repo_cred_summary:
+            repo_cred_summary[repo] = {
+                "oidc": 0,
+                "long_lived_credentials": 0,
+                "mixed": 0,
+                "no_cloud_auth_detected": 0,
+                "could_not_load": 0,
+                "total_workflows": 0,
+            }
+        repo_cred_summary[repo]["total_workflows"] += 1
+        repo_cred_summary[repo][f["posture"]] += 1
+
+    cred_repo_rows = [
+        {
+            "repo": repo,
+            "total_workflows": counts["total_workflows"],
+            "oidc": counts["oidc"],
+            "long_lived_credentials": counts["long_lived_credentials"],
+            "mixed": counts["mixed"],
+            "no_cloud_auth_detected": counts["no_cloud_auth_detected"],
+            "could_not_load": counts["could_not_load"],
+        }
+        for repo, counts in sorted(
+            repo_cred_summary.items(),
+            key=lambda x: x[1]["long_lived_credentials"],
+            reverse=True,
+        )
+    ]
+
+    cred_repo_count = CsvCompiler.write_rows(
+        "github_workflow_credential_posture_per_repo.csv", cred_repo_rows
+    )
+    print(
+        f"Wrote github_workflow_credential_posture_per_repo.csv"
+        f" ({cred_repo_count} rows)"
+    )
+
+    oidc_only = sum(1 for f in all_credential_findings if f["posture"] == "oidc")
+    long_lived = sum(
+        1 for f in all_credential_findings if f["posture"] == "long_lived_credentials"
+    )
+    mixed = sum(1 for f in all_credential_findings if f["posture"] == "mixed")
+    no_cloud = sum(
+        1 for f in all_credential_findings if f["posture"] == "no_cloud_auth_detected"
+    )
+    skipped = sum(
+        1 for f in all_credential_findings if f["posture"] == "could_not_load"
+    )
+
+    print(f"OIDC only: {oidc_only}")
+    print(f"Long-lived credentials only: {long_lived}")
+    print(f"Mixed (both): {mixed}")
+    print(f"No cloud auth detected: {no_cloud}")
     print(f"Could not load: {skipped}")
 
     print("--- Complete ---")

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -31,12 +31,14 @@ from core.github_api import (
     fetch_repo_file_text,
     list_org_repos,
     check_workflow_permissions,
+    check_credential_posture,
 )
 from core.models import (
     AlertData,
     BranchProtection,
     CodeownersData,
     CommunityProfile,
+    CredentialPostureFinding,
     DependencyGraphData,
     ForkTemplateData,
     LatestWorkflowRunData,
@@ -776,4 +778,64 @@ class TestCheckWorkflowPermissions:
             client, "moj", "my-repo", ".github/workflows/deploy.yml"
         )
         assert result.repo == "moj/my-repo"
+        assert result.workflow_path == ".github/workflows/deploy.yml"
+
+
+# — check_credential_posture ——————————————————
+
+
+class TestCheckCredentialPosture:
+    def _make_client(self, content: str | None) -> MockHttpClient:
+        if content is None:
+            return MockHttpClient()
+        import base64
+
+        encoded = base64.b64encode(content.encode()).decode()
+        return MockHttpClient(
+            {
+                "/repos/o/r/contents/.github/workflows/ci.yml": {
+                    "encoding": "base64",
+                    "content": encoded,
+                }
+            }
+        )
+
+    def test_could_not_load(self) -> None:
+        client = self._make_client(None)
+        result = check_credential_posture(client, "o", "r", ".github/workflows/ci.yml")
+        assert isinstance(result, CredentialPostureFinding)
+        assert result.posture == "could_not_load"
+
+    def test_oidc_detected(self) -> None:
+        client = self._make_client(
+            "permissions:\n  id-token: write\nsteps:\n  - uses: aws-actions/configure-aws-credentials@v4\n"
+        )
+        result = check_credential_posture(client, "o", "r", ".github/workflows/ci.yml")
+        assert result.posture == "oidc"
+        assert result.has_id_token_write is True
+
+    def test_long_lived_credentials_detected(self) -> None:
+        client = self._make_client(
+            "steps:\n  - run: deploy\n    env:\n      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}\n"
+        )
+        result = check_credential_posture(client, "o", "r", ".github/workflows/ci.yml")
+        assert result.posture == "long_lived_credentials"
+
+    def test_returns_correct_repo_and_path(self) -> None:
+        import base64
+
+        content = "name: CI\non: push\n"
+        encoded = base64.b64encode(content.encode()).decode()
+        client = MockHttpClient(
+            {
+                "/repos/myorg/myrepo/contents/.github/workflows/deploy.yml": {
+                    "encoding": "base64",
+                    "content": encoded,
+                }
+            }
+        )
+        result = check_credential_posture(
+            client, "myorg", "myrepo", ".github/workflows/deploy.yml"
+        )
+        assert result.repo == "myorg/myrepo"
         assert result.workflow_path == ".github/workflows/deploy.yml"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,6 +17,7 @@ from core.models import (
 )
 from core.transforms import (
     TRANSFORMS,
+    assess_credential_posture,
     BaseTransform,
     FlagTransform,
     RepoTreeTransform,
@@ -595,3 +596,55 @@ class TestParseActionsFromContentPinning:
         assert result[0]["is_pinned"] is False
         assert result[0]["pin_type"] == "mutable_tag"
         assert result[0]["owner"] == "aws-actions"
+
+
+class TestAssessCredentialPosture:
+    def test_oidc_with_id_token_write(self):
+        content = "permissions:\n  id-token: write\nsteps:\n  - uses: aws-actions/configure-aws-credentials@v4\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "oidc"
+        assert result["has_id_token_write"] is True
+        assert "aws-actions/configure-aws-credentials" in result["oidc_actions"]
+
+    def test_long_lived_credentials(self):
+        content = "steps:\n  - run: aws s3 sync\n    env:\n      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}\n      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "long_lived_credentials"
+        assert "AWS_ACCESS_KEY_ID" in result["credential_secrets_found"]
+
+    def test_mixed(self):
+        content = "permissions:\n  id-token: write\nsteps:\n  - uses: aws-actions/configure-aws-credentials@v4\n  - run: echo\n    env:\n      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "mixed"
+
+    def test_no_cloud_auth(self):
+        content = "name: CI\non: push\nsteps:\n  - uses: actions/checkout@v4\n  - run: npm test\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "no_cloud_auth_detected"
+        assert result["oidc_actions"] == ""
+        assert result["credential_secrets_found"] == ""
+
+    def test_azure_login_is_oidc(self):
+        content = "permissions:\n  id-token: write\nsteps:\n  - uses: azure/login@v2\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "oidc"
+        assert "azure/login" in result["oidc_actions"]
+
+    def test_id_token_write_without_oidc_action(self):
+        content = (
+            "permissions:\n  id-token: write\nsteps:\n  - uses: actions/checkout@v4\n"
+        )
+        result = assess_credential_posture(content)
+        assert result["posture"] == "oidc"
+        assert result["has_id_token_write"] is True
+
+    def test_azure_credentials_secret_is_mixed(self):
+        content = "steps:\n  - uses: azure/login@v2\n    with:\n      creds: ${{ secrets.AZURE_CREDENTIALS }}\n"
+        result = assess_credential_posture(content)
+        assert result["posture"] == "mixed"
+
+    def test_no_repo_or_path_in_result(self):
+        content = "name: CI\n"
+        result = assess_credential_posture(content)
+        assert "repo" not in result
+        assert "workflow_path" not in result

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,8 +17,8 @@ from core.models import (
 )
 from core.transforms import (
     TRANSFORMS,
-    assess_credential_posture,
     BaseTransform,
+    CredentialPostureTransform,
     FlagTransform,
     RepoTreeTransform,
     ReferenceClassifier,
@@ -44,7 +44,12 @@ class TestBaseTransform:
 
 class TestTransformRegistry:
     def test_order(self):
-        assert TRANSFORMS == [TimestampTransform, ReferenceClassifier, FlagTransform]
+        assert TRANSFORMS == [
+            TimestampTransform,
+            ReferenceClassifier,
+            FlagTransform,
+            CredentialPostureTransform,
+        ]
 
     def test_all_have_name_and_apply(self):
         for cls in TRANSFORMS:
@@ -601,32 +606,32 @@ class TestParseActionsFromContentPinning:
 class TestAssessCredentialPosture:
     def test_oidc_with_id_token_write(self):
         content = "permissions:\n  id-token: write\nsteps:\n  - uses: aws-actions/configure-aws-credentials@v4\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "oidc"
         assert result["has_id_token_write"] is True
         assert "aws-actions/configure-aws-credentials" in result["oidc_actions"]
 
     def test_long_lived_credentials(self):
         content = "steps:\n  - run: aws s3 sync\n    env:\n      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}\n      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "long_lived_credentials"
         assert "AWS_ACCESS_KEY_ID" in result["credential_secrets_found"]
 
     def test_mixed(self):
         content = "permissions:\n  id-token: write\nsteps:\n  - uses: aws-actions/configure-aws-credentials@v4\n  - run: echo\n    env:\n      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "mixed"
 
     def test_no_cloud_auth(self):
         content = "name: CI\non: push\nsteps:\n  - uses: actions/checkout@v4\n  - run: npm test\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "no_cloud_auth_detected"
         assert result["oidc_actions"] == ""
         assert result["credential_secrets_found"] == ""
 
     def test_azure_login_is_oidc(self):
         content = "permissions:\n  id-token: write\nsteps:\n  - uses: azure/login@v2\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "oidc"
         assert "azure/login" in result["oidc_actions"]
 
@@ -634,17 +639,17 @@ class TestAssessCredentialPosture:
         content = (
             "permissions:\n  id-token: write\nsteps:\n  - uses: actions/checkout@v4\n"
         )
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "oidc"
         assert result["has_id_token_write"] is True
 
     def test_azure_credentials_secret_is_mixed(self):
         content = "steps:\n  - uses: azure/login@v2\n    with:\n      creds: ${{ secrets.AZURE_CREDENTIALS }}\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert result["posture"] == "mixed"
 
     def test_no_repo_or_path_in_result(self):
         content = "name: CI\n"
-        result = assess_credential_posture(content)
+        result = CredentialPostureTransform.assess_credential_posture(content)
         assert "repo" not in result
         assert "workflow_path" not in result


### PR DESCRIPTION
# Introduction :pencil2:

Closes #31 — Assess OIDC usage vs Long-Lived Cloud Credentials across the MoJ GitHub estate.

Adds a new Stage 8 to the workflow posture scanner that checks every workflow file for OIDC adoption indicators and long-lived credential secret patterns, classifying each as `oidc`, `long_lived_credentials`, `mixed`, `no_cloud_auth_detected`, or `could_not_load`.

## Resolution :heavy_check_mark:

**6 files changed, following the approved core architecture pattern:**

**core/models.py**
- Added `CredentialPostureFinding` Pydantic model — fields: `repo`, `workflow_path`, `has_id_token_write`, `oidc_actions`, `credential_secrets_found`, `posture`

**core/transforms.py**
- Added `assess_credential_posture()` pure function — parses workflow content for OIDC indicators (`id-token: write`, `aws-actions/configure-aws-credentials`, `azure/login`, `google-github-actions/auth`) and long-lived credential secret patterns (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AZURE_CLIENT_SECRET`, `AZURE_CREDENTIALS`, `GCP_SA_KEY`, etc.)
- Classifies each workflow as `oidc`, `long_lived_credentials`, `mixed`, `no_cloud_auth_detected`, or `could_not_load`

**core/github_api.py**
- Added `check_credential_posture()` wrapper — fetches workflow content via `fetch_repo_file_text`, calls `assess_credential_posture`, returns `CredentialPostureFinding` model

**github_workflow.py**
- Added Stage 8 in `main()` — loops through all workflow files, calls `check_credential_posture`, outputs two CSVs:
  - `github_workflow_credential_posture.csv` (per-workflow)
  - `github_workflow_credential_posture_per_repo.csv` (per-repo summary sorted by long-lived credential count)

**tests/test_transforms.py**
- 8 new tests for `assess_credential_posture`: OIDC with id-token write, long-lived credentials, mixed, no cloud auth, Azure login, id-token without OIDC action, Azure credentials secret, and no repo/path in result

**tests/test_github_api.py**
- 4 new tests for `check_credential_posture`: could not load, OIDC detected, long-lived credentials detected, and correct repo/path passthrough — using MockHttpClient with base64-encoded content

## Scan Results

- **3,787 workflow files** checked
- OIDC only: **640**
- Long-lived credentials only: **8**
- Mixed (both): **24**
- No cloud auth detected: **2,407**
- Could not load: **708


## Miscellaneous :heavy_plus_sign:

- No new dependencies required
- Follows existing architecture: pure transform logic in `core/transforms.py`, API wrapper in `core/github_api.py`, orchestration in `main()`, output via `CsvCompiler`
- Findings are heuristic/indicative — secret naming is not standardised across teams

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>
Add screenshots of terminal output and CSV files here.

</details>

Closes #31
