### PR TITLE
feat: analyse workflow config risk

### DIFF
--- a/core/github_api.py
+++ b/core/github_api.py
@@ -34,7 +34,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from core.transforms import parse_workflow_permissions
+from core.transforms import parse_workflow_permissions, TriggerRiskTransform
 
 from core.github_client import BaseHttpClient
 from core.models import (
@@ -61,6 +61,7 @@ from core.models import (
     RepoArchivedAt,
     RepoDetails,
     RepoTreeData,
+    TriggerRiskFinding,
     WorkflowAnalysis,
     WorkflowData,
     WorkflowPermissionFinding,
@@ -223,6 +224,29 @@ def fetch_repo_alerts(
     endpoint = endpoint_map[kind]
     items = client.get_paginated(f"/repos/{owner}/{repo}/{endpoint}")
     return [item for item in items if isinstance(item, dict)]
+
+
+def check_trigger_risk(
+    client: BaseHttpClient,
+    owner: str,
+    repo_name: str,
+    workflow_path: str,
+) -> TriggerRiskFinding:
+    """Check if a workflow has risky trigger configurations."""
+    content = fetch_repo_file_text(client, owner, repo_name, workflow_path)
+    if content is None:
+        return TriggerRiskFinding(
+            repo=f"{owner}/{repo_name}",
+            workflow_path=workflow_path,
+            posture="could_not_load",
+        )
+
+    parsed = TriggerRiskTransform.assess_trigger_risk(content)
+    return TriggerRiskFinding(
+        repo=f"{owner}/{repo_name}",
+        workflow_path=workflow_path,
+        **parsed,
+    )
 
 
 # ── Abstract bases ────────────────────────────────────────────────────

--- a/core/models.py
+++ b/core/models.py
@@ -387,3 +387,18 @@ class RepoTreeProcessedData(BaseModel):
     large_blobs: list[LargeBlobData] = Field(default_factory=list)
     exceeds_soft_limit: bool = False
     exceeds_hard_limit: bool = False
+
+
+class TriggerRiskFinding(BaseModel):
+    """Result of analysing workflow trigger configuration risk."""
+
+    repo: str = ""
+    workflow_path: str = ""
+    triggers_found: str = ""
+    risky_triggers: str = ""
+    risk_level: str = ""
+    has_pull_request_target: bool = False
+    has_issue_comment: bool = False
+    has_repository_dispatch: bool = False
+    has_workflow_dispatch: bool = False
+    posture: str = ""

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -20,6 +20,7 @@ mutating the model in place.  Pydantic models are designed for this pattern.
 
 from __future__ import annotations
 
+from typing import Any
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 import re
@@ -278,6 +279,138 @@ class RepoTreeTransform(BaseTransform):
         return data.model_copy(update={"repo_tree_transform": processed})
 
 
+class TriggerRiskTransform(BaseTransform):
+    """Analyse workflow trigger configurations for security risk."""
+
+    HIGH_RISK_TRIGGERS = ("pull_request_target",)
+
+    MEDIUM_RISK_TRIGGERS = (
+        "issue_comment",
+        "issues",
+        "repository_dispatch",
+    )
+
+    LOW_RISK_TRIGGERS = (
+        "workflow_dispatch",
+        "fork",
+    )
+
+    ALL_RISKY_TRIGGERS = HIGH_RISK_TRIGGERS + MEDIUM_RISK_TRIGGERS + LOW_RISK_TRIGGERS
+
+    @property
+    def name(self) -> str:
+        return "trigger_risk"
+
+    @staticmethod
+    def assess_trigger_risk(content: str) -> dict[str, Any]:
+        """Parse workflow content for trigger configurations and assess risk."""
+
+        triggers_found: list[str] = []
+        risky_triggers: list[str] = []
+        has_pull_request_target = False
+        has_issue_comment = False
+        has_repository_dispatch = False
+        has_workflow_dispatch = False
+
+        in_on_block = False
+        on_block_indent = 0
+
+        for line in content.splitlines():
+            stripped = line.strip()
+
+            # Single-line on: trigger or on: [trigger, trigger]
+            if stripped.startswith("on:") and not in_on_block:
+                rest = stripped[3:].strip()
+                if rest:
+                    rest = rest.strip("[]")
+                    for trigger in rest.split(","):
+                        trigger = trigger.strip().strip("'\"")
+                        if trigger:
+                            triggers_found.append(trigger)
+                else:
+                    in_on_block = True
+                    on_block_indent = len(line) - len(line.lstrip())
+                continue
+
+            if stripped.startswith('"on":') or stripped.startswith("'on':"):
+                rest = stripped.split(":", 1)[1].strip()
+                if rest:
+                    rest = rest.strip("[]")
+                    for trigger in rest.split(","):
+                        trigger = trigger.strip().strip("'\"")
+                        if trigger:
+                            triggers_found.append(trigger)
+                else:
+                    in_on_block = True
+                    on_block_indent = len(line) - len(line.lstrip())
+                continue
+
+            # Inside multi-line on: block
+            if in_on_block:
+                if not stripped or stripped.startswith("#"):
+                    continue
+                current_indent = len(line) - len(line.lstrip())
+                if (
+                    current_indent <= on_block_indent
+                    and stripped
+                    and not stripped.startswith("#")
+                ):
+                    in_on_block = False
+                else:
+                    if ":" in stripped:
+                        trigger = stripped.split(":")[0].strip().strip("'\"")
+                        if trigger and not trigger.startswith("#"):
+                            triggers_found.append(trigger)
+
+        # Deduplicate
+        triggers_found = list(dict.fromkeys(triggers_found))
+
+        # Classify
+        for trigger in triggers_found:
+            if trigger in TriggerRiskTransform.ALL_RISKY_TRIGGERS:
+                risky_triggers.append(trigger)
+            if trigger == "pull_request_target":
+                has_pull_request_target = True
+            if trigger == "issue_comment":
+                has_issue_comment = True
+            if trigger == "repository_dispatch":
+                has_repository_dispatch = True
+            if trigger == "workflow_dispatch":
+                has_workflow_dispatch = True
+
+        # Determine risk level
+        if any(t in TriggerRiskTransform.HIGH_RISK_TRIGGERS for t in risky_triggers):
+            risk_level = "high"
+        elif any(
+            t in TriggerRiskTransform.MEDIUM_RISK_TRIGGERS for t in risky_triggers
+        ):
+            risk_level = "medium"
+        elif any(t in TriggerRiskTransform.LOW_RISK_TRIGGERS for t in risky_triggers):
+            risk_level = "low"
+        else:
+            risk_level = "none"
+
+        if risky_triggers:
+            posture = "risky_triggers_detected"
+        else:
+            posture = "no_risky_triggers"
+
+        return {
+            "triggers_found": "; ".join(triggers_found) if triggers_found else "",
+            "risky_triggers": "; ".join(risky_triggers) if risky_triggers else "",
+            "risk_level": risk_level,
+            "has_pull_request_target": has_pull_request_target,
+            "has_issue_comment": has_issue_comment,
+            "has_repository_dispatch": has_repository_dispatch,
+            "has_workflow_dispatch": has_workflow_dispatch,
+            "posture": posture,
+        }
+
+    def apply(self, data: RepoData) -> RepoData:
+        """No-op at repo level — trigger risk is assessed per-workflow in Stage 9."""
+        return data
+
+
 # — Standalone parsing helpers ————————————————————————
 
 
@@ -387,4 +520,5 @@ TRANSFORMS: list[type[BaseTransform]] = [
     TimestampTransform,
     ReferenceClassifier,
     FlagTransform,
+    TriggerRiskTransform,
 ]

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -26,6 +26,7 @@ from core.github_api import (
     RepoActionsPermissionsEndpoint,
     WorkflowsEndpoint,
     check_workflow_permissions,
+    check_trigger_risk,
     fetch_repo_file_text,
     list_org_repos,
 )
@@ -530,6 +531,91 @@ def main() -> None:
     print(f"Has write scope: {has_write_count}")
     print(f"Compliant (read-only): {compliant_count}")
     print(f"Could not load: {skipped}")
+
+    # ================================================================
+    # Stage 9: Analysing workflow trigger config risk
+    # ================================================================
+
+    # 9. Workflow trigger risk analysis
+    print("\n--- Analysing workflow trigger risk ---")
+
+    all_trigger_findings: List[Dict[str, Any]] = []
+    for i, row in enumerate(detail_rows):
+        finding = check_trigger_risk(
+            client, row["owner"], row["repo_name"], row["path"]
+        )
+        all_trigger_findings.append(finding.model_dump())
+
+        if (i + 1) % 100 == 0:
+            print(f"    Checked {i + 1} / {len(detail_rows)} workflow files")
+            time.sleep(0.1)
+
+    trigger_count = CsvCompiler.write_rows(
+        "github_workflow_trigger_risk.csv", all_trigger_findings
+    )
+    print(f"Wrote github_workflow_trigger_risk.csv ({trigger_count} rows)")
+
+    repo_trigger_summary: Dict[str, Dict[str, int]] = {}
+    for f in all_trigger_findings:
+        repo = f["repo"]
+        if repo not in repo_trigger_summary:
+            repo_trigger_summary[repo] = {
+                "total_workflows": 0,
+                "high_risk": 0,
+                "medium_risk": 0,
+                "low_risk": 0,
+                "no_risk": 0,
+                "could_not_load": 0,
+            }
+        repo_trigger_summary[repo]["total_workflows"] += 1
+        if f["posture"] == "could_not_load":
+            repo_trigger_summary[repo]["could_not_load"] += 1
+        elif f["risk_level"] == "high":
+            repo_trigger_summary[repo]["high_risk"] += 1
+        elif f["risk_level"] == "medium":
+            repo_trigger_summary[repo]["medium_risk"] += 1
+        elif f["risk_level"] == "low":
+            repo_trigger_summary[repo]["low_risk"] += 1
+        else:
+            repo_trigger_summary[repo]["no_risk"] += 1
+
+    trigger_repo_rows = [
+        {
+            "repo": repo,
+            "total_workflows": counts["total_workflows"],
+            "high_risk": counts["high_risk"],
+            "medium_risk": counts["medium_risk"],
+            "low_risk": counts["low_risk"],
+            "no_risk": counts["no_risk"],
+            "could_not_load": counts["could_not_load"],
+        }
+        for repo, counts in sorted(
+            repo_trigger_summary.items(),
+            key=lambda x: x[1]["high_risk"],
+            reverse=True,
+        )
+    ]
+
+    trigger_summary_count = CsvCompiler.write_rows(
+        "github_workflow_trigger_risk_per_repo.csv", trigger_repo_rows
+    )
+    print(
+        f"Wrote github_workflow_trigger_risk_per_repo.csv ({trigger_summary_count} rows)"
+    )
+
+    high_count = sum(1 for f in all_trigger_findings if f["risk_level"] == "high")
+    medium_count = sum(1 for f in all_trigger_findings if f["risk_level"] == "medium")
+    low_count = sum(1 for f in all_trigger_findings if f["risk_level"] == "low")
+    no_risk_count = sum(1 for f in all_trigger_findings if f["risk_level"] == "none")
+    could_not_load_count = sum(
+        1 for f in all_trigger_findings if f["posture"] == "could_not_load"
+    )
+
+    print(f"High risk: {high_count}")
+    print(f"Medium risk: {medium_count}")
+    print(f"Low risk: {low_count}")
+    print(f"No risk: {no_risk_count}")
+    print(f"Could not load: {could_not_load_count}")
 
     print("--- Complete ---")
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -32,6 +32,7 @@ from core.github_api import (
     fetch_repo_file_text,
     list_org_repos,
     check_workflow_permissions,
+    check_trigger_risk,
 )
 from core.models import (
     AlertData,
@@ -49,6 +50,7 @@ from core.models import (
     RepoActionsPermissionsData,
     RepoDetails,
     RepoTreeData,
+    TriggerRiskFinding,
     WorkflowData,
     WorkflowPermissionFinding,
 )
@@ -796,4 +798,66 @@ class TestCheckWorkflowPermissions:
             client, "moj", "my-repo", ".github/workflows/deploy.yml"
         )
         assert result.repo == "moj/my-repo"
+        assert result.workflow_path == ".github/workflows/deploy.yml"
+
+
+# — CheckWorkflowTriggerRisk ————————————————————————
+
+
+class TestCheckTriggerRisk:
+    def _make_client(self, content: str | None) -> MockHttpClient:
+        if content is None:
+            return MockHttpClient()
+        import base64
+
+        encoded = base64.b64encode(content.encode()).decode()
+        return MockHttpClient(
+            {
+                "/repos/o/r/contents/.github/workflows/ci.yml": {
+                    "encoding": "base64",
+                    "content": encoded,
+                }
+            }
+        )
+
+    def test_could_not_load(self) -> None:
+        client = self._make_client(None)
+        result = check_trigger_risk(client, "o", "r", ".github/workflows/ci.yml")
+        assert isinstance(result, TriggerRiskFinding)
+        assert result.posture == "could_not_load"
+
+    def test_high_risk_detected(self) -> None:
+        client = self._make_client(
+            "on:\n  pull_request_target:\n    branches: [main]\njobs:\n  build:\n"
+        )
+        result = check_trigger_risk(client, "o", "r", ".github/workflows/ci.yml")
+        assert result.posture == "risky_triggers_detected"
+        assert result.risk_level == "high"
+        assert result.has_pull_request_target is True
+
+    def test_no_risk_detected(self) -> None:
+        client = self._make_client(
+            "on:\n  push:\n    branches: [main]\njobs:\n  build:\n"
+        )
+        result = check_trigger_risk(client, "o", "r", ".github/workflows/ci.yml")
+        assert result.posture == "no_risky_triggers"
+        assert result.risk_level == "none"
+
+    def test_returns_correct_repo_and_path(self) -> None:
+        import base64
+
+        content = "name: CI\non: push\n"
+        encoded = base64.b64encode(content.encode()).decode()
+        client = MockHttpClient(
+            {
+                "/repos/myorg/myrepo/contents/.github/workflows/deploy.yml": {
+                    "encoding": "base64",
+                    "content": encoded,
+                }
+            }
+        )
+        result = check_trigger_risk(
+            client, "myorg", "myrepo", ".github/workflows/deploy.yml"
+        )
+        assert result.repo == "myorg/myrepo"
         assert result.workflow_path == ".github/workflows/deploy.yml"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -21,6 +21,7 @@ from core.transforms import (
     FlagTransform,
     RepoTreeTransform,
     ReferenceClassifier,
+    TriggerRiskTransform,
     SOFT_LIMIT,
     TimestampTransform,
     parse_workflow_permissions,
@@ -43,7 +44,12 @@ class TestBaseTransform:
 
 class TestTransformRegistry:
     def test_order(self):
-        assert TRANSFORMS == [TimestampTransform, ReferenceClassifier, FlagTransform]
+        assert TRANSFORMS == [
+            TimestampTransform,
+            ReferenceClassifier,
+            FlagTransform,
+            TriggerRiskTransform,
+        ]
 
     def test_all_have_name_and_apply(self):
         for cls in TRANSFORMS:
@@ -595,3 +601,68 @@ class TestParseActionsFromContentPinning:
         assert result[0]["is_pinned"] is False
         assert result[0]["pin_type"] == "mutable_tag"
         assert result[0]["owner"] == "aws-actions"
+
+
+class TestTriggerRiskTransform:
+    def test_pull_request_target_is_high_risk(self):
+        content = "on:\n  pull_request_target:\n    branches: [main]\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "high"
+        assert result["has_pull_request_target"] is True
+        assert "pull_request_target" in result["risky_triggers"]
+        assert result["posture"] == "risky_triggers_detected"
+
+    def test_issue_comment_is_medium_risk(self):
+        content = "on:\n  issue_comment:\n    types: [created]\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "medium"
+        assert result["has_issue_comment"] is True
+
+    def test_repository_dispatch_is_medium_risk(self):
+        content = "on:\n  repository_dispatch:\n    types: [deploy]\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "medium"
+        assert result["has_repository_dispatch"] is True
+
+    def test_workflow_dispatch_is_low_risk(self):
+        content = "on:\n  workflow_dispatch:\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "low"
+        assert result["has_workflow_dispatch"] is True
+
+    def test_push_only_is_no_risk(self):
+        content = "on:\n  push:\n    branches: [main]\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "none"
+        assert result["posture"] == "no_risky_triggers"
+
+    def test_single_line_on(self):
+        content = "on: push\njobs:\n  build:\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert "push" in result["triggers_found"]
+        assert result["risk_level"] == "none"
+
+    def test_inline_array_on(self):
+        content = "on: [push, pull_request_target]\njobs:\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["has_pull_request_target"] is True
+        assert result["risk_level"] == "high"
+
+    def test_multiple_risky_triggers(self):
+        content = "on:\n  pull_request_target:\n  issue_comment:\n  push:\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "high"
+        assert result["has_pull_request_target"] is True
+        assert result["has_issue_comment"] is True
+
+    def test_empty_content(self):
+        content = ""
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert result["risk_level"] == "none"
+        assert result["triggers_found"] == ""
+
+    def test_no_repo_or_path_in_result(self):
+        content = "on: push\n"
+        result = TriggerRiskTransform.assess_trigger_risk(content)
+        assert "repo" not in result
+        assert "workflow_path" not in result


### PR DESCRIPTION
# Introduction :pencil2:

Closes #40 — Analyse Workflow Trigger Configuration Risk across the MoJ GitHub estate.

Adds a new Stage 9 to the workflow posture scanner that checks every workflow file for trigger configurations and classifies them by risk level. Certain triggers like `pull_request_target` allow external contributors to run code inside CI/CD pipelines with access to secrets, so identifying these is critical for security posture.

## Resolution :heavy_check_mark:

**6 files changed, following the approved core architecture pattern:**

**core/models.py**
- Added `TriggerRiskFinding` Pydantic model — fields: `repo`, `workflow_path`, `triggers_found`, `risky_triggers`, `risk_level`, `has_pull_request_target`, `has_issue_comment`, `has_repository_dispatch`, `has_workflow_dispatch`, `posture`

**core/transforms.py**
- Added `TriggerRiskTransform(BaseTransform)` class with `assess_trigger_risk()` static method — parses workflow content for trigger configurations and classifies risk as high (`pull_request_target`), medium (`issue_comment`, `issues`, `repository_dispatch`), or low (`workflow_dispatch`, `fork`)
- Handles single-line `on:`, inline arrays `on: [push, pull_request_target]`, and multi-line `on:` blocks
- Registered in `TRANSFORMS` list

**core/github_api.py**
- Added `check_trigger_risk()` wrapper — fetches workflow content via `fetch_repo_file_text`, calls `TriggerRiskTransform.assess_trigger_risk`, returns `TriggerRiskFinding` model

**github_workflow.py**
- Added Stage 9 in `main()` — loops through all workflow files, calls `check_trigger_risk`, outputs two CSVs:
  - `github_workflow_trigger_risk.csv` (per-workflow trigger classification)
  - `github_workflow_trigger_risk_per_repo.csv` (per-repo summary sorted by high-risk count)

**tests/test_transforms.py**
- 10 new tests for `assess_trigger_risk`: high risk (pull_request_target), medium risk (issue_comment, repository_dispatch), low risk (workflow_dispatch), no risk (push only), single-line on, inline array on, multiple risky triggers, empty content, and no repo/path in result

**tests/test_github_api.py**
- 4 new tests for `check_trigger_risk`: could not load, high risk detected, no risk detected, and correct repo/path passthrough — using the same `_make_client` helper pattern as `TestCheckCredentialPosture`

## Scan Results

- **3,851 workflow files** checked
- High risk: **11**
- Medium risk: **13**
- Low risk: **1,839**
- No risk: **1,268**
- Could not load: **720**

## Miscellaneous :heavy_plus_sign:

- No new dependencies required
- Follows the `BaseTransform` pattern as requested by Osanda on PR #105
- Findings are heuristic — trigger names are parsed from YAML `on:` blocks

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots of terminal output and CSV files here.

</details>

Closes #40
# Introduction :pencil2:

Include a summary of the changes and related feature(s) or issue(s).

## Resolution :heavy_check_mark:

List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>