### PR TITLE
feat: add YAML config control for audit scripts

### DIFF
--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -1,0 +1,18 @@
+# Default audit config for moj-github-discovery scripts.
+# Override by passing --config-file path/to/your.yaml on the CLI.
+
+# Global attributes used by all scripts
+repo_list_file: "repo_list.yaml"
+
+# Stage toggles for github_workflow.py.
+# Stages 2 and 3 collect the base data the later stages depend on,
+# so disabling them only makes sense when a previous run has already
+# populated the SQLite cache (default: github_workflow_posture.db).
+workflow_audit:
+  collect_baseline_data: true    # stage 2 - repo metadata + workflow inventory
+  collect_additional_data: true  # stage 3 - Actions permissions + latest run
+  gen_posture_reports: true      # stage 4/5 - posture CSVs + summary.txt
+  actions_analysis: true         # stage 6 - action usage + SHA pinning
+  permissions_analysis: true     # stage 7 - workflow permissions
+  credentials_analysis: true     # stage 8 - OIDC vs long-lived
+  trigger_risk_analysis: true    # stage 9 - trigger config risk

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,65 @@
+"""Audit config loading for moj-github-discovery scripts.
+
+The default config lives at ``config/audit_config.yaml`` relative to the
+repository root. Callers may override it by passing an explicit path via
+the ``--config-file`` CLI argument on any script that consumes this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class WorkflowAuditConfig(BaseModel):
+    """Per-stage toggles for ``github_workflow.py``."""
+
+    collect_baseline_data: bool = True  # stage 2
+    collect_additional_data: bool = True  # stage 3
+    gen_posture_reports: bool = True  # stage 4/5
+    actions_analysis: bool = True  # stage 6
+    permissions_analysis: bool = True  # stage 7
+    credentials_analysis: bool = True  # stage 8
+    trigger_risk_analysis: bool = True  # stage 9
+
+
+class AuditConfig(BaseModel):
+    """Top-level audit config loaded from ``audit_config.yaml``."""
+
+    repo_list_file: str = "repo_list.yaml"
+    workflow_audit: WorkflowAuditConfig = Field(default_factory=WorkflowAuditConfig)
+
+
+DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
+
+
+def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
+    """Load an :class:`AuditConfig` from disk.
+
+    Behaviour:
+
+    * If ``config_path`` is ``None``, the function looks for the default
+      file at ``config/audit_config.yaml``. If that file is missing, a
+      fully-defaulted :class:`AuditConfig` is returned (all stages on).
+    * If ``config_path`` is provided but the file does not exist, a
+      :class:`FileNotFoundError` is raised — the caller asked for a
+      specific file and we should not silently fall back.
+    * Missing fields in the YAML fall back to model defaults, so a
+      partial config only needs to list the toggles being changed.
+    """
+    if config_path is None:
+        resolved = DEFAULT_CONFIG_PATH
+        if not resolved.exists():
+            return AuditConfig()
+    else:
+        resolved = Path(config_path)
+        if not resolved.exists():
+            raise FileNotFoundError(f"Config file not found: {resolved}")
+
+    with resolved.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    return AuditConfig(**data)

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -2,24 +2,28 @@
 """GitHub Actions workflow posture discovery.
 
 Refactored to use core modules:
-  - Repo discovery / loading     core.github_api.list_org_repos, core.repo_list
-  - HTTP transport               core.github_client.GitHubHttpClient
-    - Workflow + repo data         RepoCollector with typed repo-scoped endpoints
+    - Repo discovery / loading      core.github_api.list_org_repos, core.repo_list
+    - HTTP transport                core.github_client.GitHubHttpClient
+    - Workflow + repo data          RepoCollector with typed repo-scoped endpoints
+    - Stage toggles                 core.config.load_audit_config
 
 Not yet in core (local implementations retained):
-  - Workflow YAML uses: parsing
+    - Workflow YAML uses: parsing
 """
 
 import argparse
 import os
 import sys
 import time
+import sqlite3
 from collections import Counter
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
 
 from core.collector import RepoCollector
 from core.compiler import CsvCompiler
+from core.config import AuditConfig, load_audit_config
 from core.github_api import (
     LatestWorkflowRunEndpoint,
     RepoDetailsEndpoint,
@@ -41,6 +45,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_DB = os.path.join(SCRIPT_DIR, "github_workflow_posture.db")
 
 
+# --- Workflow file parsing ------------------------------------------------
+
+
 def parse_actions_from_workflow(
     client: GitHubHttpClient,
     owner: str,
@@ -55,17 +62,13 @@ def parse_actions_from_workflow(
             file=sys.stderr,
         )
         return []
-
     return parse_actions_from_content(content, repo_name, workflow_path)
 
 
-# ── Row builders ─────────────────────────────────────────────────────
+# --- Row builders ---------------------------------------------------------
 
 
-def build_repo_row(
-    full_name: str,
-    data: RepoData,
-) -> Dict[str, Any]:
+def build_repo_row(full_name: str, data: RepoData) -> Dict[str, Any]:
     """Build a posture summary row from collected RepoData."""
     repo = data.repo_details
     workflows = data.workflows
@@ -119,14 +122,11 @@ def build_repo_row(
     }
 
 
-def build_workflow_detail_rows(
-    full_name: str,
-    data: RepoData,
-) -> List[Dict[str, Any]]:
+def build_workflow_detail_rows(full_name: str, data: RepoData) -> List[Dict[str, Any]]:
     """Build one detail row per workflow from WorkflowData."""
     owner, _, repo_name = full_name.partition("/")
     workflows = data.workflows
-    rows = []
+    rows: List[Dict[str, Any]] = []
     for wf in workflows.workflows if workflows else []:
         rows.append(
             {
@@ -141,7 +141,7 @@ def build_workflow_detail_rows(
     return rows
 
 
-# ── Summary report ────────────────────────────────────────────────────
+# --- Summary report -------------------------------------------------------
 
 
 def write_summary(
@@ -176,20 +176,20 @@ def write_summary(
         "=" * 70,
         "",
         "OVERVIEW",
-        "_" * 40,
+        "-" * 40,
         f"  Total repositories scanned:       {total}",
-        f"  Repos using GitHub Actions:        {len(with_wf)} ({len(with_wf) / max(total, 1) * 100:.1f}%)",
-        f"  Repos NOT using GitHub Actions:    {len(without_wf)} ({len(without_wf) / max(total, 1) * 100:.1f}%)",
-        f"  Total workflow files found:        {len(detail_rows)}",
+        f"  Repos using GitHub Actions:       {len(with_wf)} ({len(with_wf) / max(total, 1) * 100:.1f}%)",
+        f"  Repos NOT using GitHub Actions:   {len(without_wf)} ({len(without_wf) / max(total, 1) * 100:.1f}%)",
+        f"  Total workflow files found:       {len(detail_rows)}",
         "",
         "BREAKDOWN",
-        "_" * 40,
-        f"  Active repos with workflows:       {len(active_with)}",
-        f"  Active repos without workflows:    {len(active_without)}",
-        f"  Archived repos with workflows:     {len(archived_with)}",
-        f"  Archived repos without workflows:  {len(archived_without)}",
+        "-" * 40,
+        f"  Active repos with workflows:      {len(active_with)}",
+        f"  Active repos without workflows:   {len(active_without)}",
+        f"  Archived repos with workflows:    {len(archived_with)}",
+        f"  Archived repos without workflows: {len(archived_without)}",
         "",
-        f"  Candidates for disabling Actions:  {len(disable_candidates)}",
+        f"  Candidates for disabling Actions: {len(disable_candidates)}",
         "  (archived repos with workflows + active repos with Actions enabled but no workflow files)",
         "",
     ]
@@ -235,10 +235,10 @@ def write_summary(
     print(report)
 
 
-# ── Main ──────────────────────────────────────────────────────────────
+# --- CLI ------------------------------------------------------------------
 
 
-def main() -> None:
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Identify repositories using GitHub Actions across the MoJ estate"
     )
@@ -249,7 +249,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--repos",
-        nargs="*",
+        nargs="+",
         help="Specific repos to scan, e.g. owner/repo owner/repo",
     )
     parser.add_argument(
@@ -283,19 +283,51 @@ def main() -> None:
         default=None,
         help="Select GitHub authentication method explicitly",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--config-file",
+        type=Path,
+        default=None,
+        help=(
+            "Path to audit config YAML. Defaults to config/audit_config.yaml "
+            "if present, otherwise all stages run with built-in defaults."
+        ),
+    )
+    return parser.parse_args()
 
-    client = GitHubHttpClient(auth_method=args.auth)
 
-    # ================================================================
-    # Stage 1: Resolve the repository list to scan
-    # ================================================================
+# --- Stage functions ------------------------------------------------------
 
-    # 1. Resolve repo list
+
+def stage_1_resolve_repo_list(
+    args: argparse.Namespace,
+    client: GitHubHttpClient,
+    config: AuditConfig,
+) -> List[str]:
+    """Stage 1: Resolve the repository list to scan (mandatory).
+
+    Resolution order:
+      1. ``--repos`` CLI arg (explicit list)
+      2. ``--repo-file`` CLI arg (explicit path)
+      3. ``repo_list_file`` from the loaded audit config, if that path exists
+      4. ``repo_list.yaml`` in the current working directory, if present
+      5. Fall back to listing the org via the GitHub API
+    """
     if args.repos:
         repo_list = args.repos[: args.limit]
     elif args.repo_file:
         repo_list = load_repo_list_file(args.repo_file)[: args.limit]
+    elif config.repo_list_file and Path(config.repo_list_file).exists():
+        print(
+            f"Using repo list from config: {config.repo_list_file}",
+            file=sys.stderr,
+        )
+        repo_list = load_repo_list_file(config.repo_list_file)[: args.limit]
+    elif Path("repo_list.yaml").exists():
+        print(
+            "Using repo_list.yaml from current directory",
+            file=sys.stderr,
+        )
+        repo_list = load_repo_list_file("repo_list.yaml")[: args.limit]
     else:
         print("Listing org repositories...", file=sys.stderr)
         try:
@@ -309,13 +341,16 @@ def main() -> None:
     if not repo_list:
         raise SystemExit("No repositories found to scan.")
     print(f"Found {len(repo_list)} repositories to scan.", file=sys.stderr)
+    return repo_list
 
-    # ================================================================
-    # Stage 2: Collect baseline repo metadata and workflow inventory
-    # ================================================================
 
-    # 2. Collect repo details + workflow inventory via core
-    storage = SqliteRepoStorage(args.db)
+def stage_2_collect_baseline(
+    args: argparse.Namespace,
+    client: GitHubHttpClient,
+    repo_list: List[str],
+    storage: SqliteRepoStorage,
+) -> None:
+    """Stage 2: Collect baseline repo metadata and workflow inventory."""
     collector = RepoCollector(
         storage=storage,
         client=client,
@@ -327,9 +362,15 @@ def main() -> None:
     primary_org = repo_list[0].split("/", 1)[0]
     collector.collect(primary_org, repos=repo_list, resume=args.resume)
 
-    # ================================================================
-    # Stage 3: Collect remaining workflow posture data
-    # ================================================================
+
+def stage_3_collect_additional(
+    args: argparse.Namespace,
+    client: GitHubHttpClient,
+    repo_list: List[str],
+    storage: SqliteRepoStorage,
+) -> None:
+    """Stage 3: Collect remaining workflow posture data."""
+    primary_org = repo_list[0].split("/", 1)[0]
 
     # 3.1 Collect repo-level Actions permissions for all repos
     collector = RepoCollector(
@@ -357,26 +398,44 @@ def main() -> None:
             resume=args.resume,
         )
 
-    # ================================================================
-    # Stage 4: Read collected data and build output row sets
-    # ================================================================
 
-    # 4. Read collected data and build output rows
+def stage_4_build_rows(
+    repo_list: List[str], storage: SqliteRepoStorage
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Stage 4: Read collected data and build output row sets.
+
+    Always runs — downstream stages need ``detail_rows``. Reads are cheap
+    (SQLite only) so there is no gain from toggling this off. if the
+    cache is empty ( e.g Stages 2/3 were skipped before any prior run
+    populated it), this returns empty rows for the affected repos and
+    lets later stages no-op gracefully, rather than crash.
+    """
     repo_rows: List[Dict[str, Any]] = []
     detail_rows: List[Dict[str, Any]] = []
     total = len(repo_list)
     for idx, full_name in enumerate(repo_list, start=1):
         print(f"[{idx}/{total}] Augmenting {full_name}...", file=sys.stderr)
-
-        data = storage.read(full_name) or RepoData()
+        try:
+            data = storage.read(full_name) or RepoData()
+        except sqlite3.OperationalError as exc:
+            print(
+                f" Cache unavailable for {full_name} ({exc}). "
+                "Skipping row build - likely Stages 2/3 were disabled "
+                "before the cache was populated.",
+                file=sys.stderr,
+            )
+            data = RepoData()
         repo_rows.append(build_repo_row(full_name, data))
         detail_rows.extend(build_workflow_detail_rows(full_name, data))
+    return repo_rows, detail_rows
 
-    # ================================================================
-    # Stage 5: Write repo-level posture reports
-    # ================================================================
 
-    # 5. Write posture outputs
+def stage_5_write_posture_reports(
+    args: argparse.Namespace,
+    repo_rows: List[Dict[str, Any]],
+    detail_rows: List[Dict[str, Any]],
+) -> None:
+    """Stage 5: Write repo-level posture reports."""
     prefix = args.out_prefix
     repo_count = CsvCompiler.write_rows(f"{prefix}_repo_summary.csv", repo_rows)
     details_count = CsvCompiler.write_rows(
@@ -386,6 +445,7 @@ def main() -> None:
     print(f"Wrote {prefix}_workflow_details.csv ({details_count} rows)")
     write_summary(f"{prefix}_summary.txt", repo_rows, detail_rows)
 
+    total = len(repo_rows)
     print(
         f"\nDone. Scanned {total} repos, "
         f"found {sum(1 for r in repo_rows if r.get('has_workflows'))} using GitHub Actions "
@@ -393,10 +453,11 @@ def main() -> None:
         file=sys.stderr,
     )
 
-    # ================================================================
-    # Stage 6: Parse workflow files to inventory action usage
-    # ================================================================
 
+def stage_6_actions_analysis(
+    client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
+) -> None:
+    """Stage 6: Parse workflow files to inventory action usage + SHA pinning."""
     # 6. Analyse most common GitHub Actions used
     print("\n--- Analysing actions used across workflows ---")
 
@@ -408,7 +469,7 @@ def main() -> None:
         all_actions.extend(actions)
         if (i + 1) % 100 == 0:
             print(f"  Parsed {i + 1} / {len(detail_rows)} workflow files")
-        time.sleep(0.1)
+            time.sleep(0.1)
 
     print(f"Total action references found: {len(all_actions)}")
 
@@ -481,7 +542,9 @@ def main() -> None:
             ),
         }
         for repo, counts in sorted(
-            repo_pinning.items(), key=lambda x: x[1]["unpinned"], reverse=True
+            repo_pinning.items(),
+            key=lambda x: x[1]["unpinned"],
+            reverse=True,
         )
     ]
 
@@ -497,11 +560,11 @@ def main() -> None:
         f"Repos fully pinned: {sum(1 for s in pinning_summary if s['unpinned'] == 0)}"
     )
 
-    # ================================================================
-    # Stage 7: Parse workflow files for permissions posture
-    # ================================================================
 
-    # 7. Workflow permissions check
+def stage_7_permissions_analysis(
+    client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
+) -> None:
+    """Stage 7: Parse workflow files for permissions posture."""
     print("\n--- Analysing workflow permissions ---")
 
     all_permissions: List[Dict[str, Any]] = []
@@ -510,10 +573,10 @@ def main() -> None:
             client, row["owner"], row["repo_name"], row["path"]
         )
         all_permissions.append(perm.model_dump())
-
         if (i + 1) % 100 == 0:
-            print(f" Checked {i + 1} / {len(detail_rows)} workflow files")
+            print(f"  Checked {i + 1} / {len(detail_rows)} workflow files")
             time.sleep(0.1)
+
     perms_count = CsvCompiler.write_rows(
         "github_workflow_permissions.csv", all_permissions
     )
@@ -533,11 +596,11 @@ def main() -> None:
     print(f"Compliant (read-only): {compliant_count}")
     print(f"Could not load: {skipped}")
 
-    # ================================================================
-    # Stage 8: Assess OIDC vs long-lived credentials
-    # ================================================================
 
-    # 8. OIDC vs long-lived credentials assessment
+def stage_8_credentials_analysis(
+    client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
+) -> None:
+    """Stage 8: Assess OIDC vs long-lived credentials."""
     print("\n--- Assessing OIDC vs long-lived credentials ---")
 
     all_credential_findings: List[Dict[str, Any]] = []
@@ -546,9 +609,8 @@ def main() -> None:
             client, row["owner"], row["repo_name"], row["path"]
         )
         all_credential_findings.append(finding.model_dump())
-
         if (i + 1) % 100 == 0:
-            print(f" Checked {i + 1} / {len(detail_rows)} workflow files")
+            print(f"  Checked {i + 1} / {len(detail_rows)} workflow files")
             time.sleep(0.1)
 
     cred_count = CsvCompiler.write_rows(
@@ -592,8 +654,8 @@ def main() -> None:
         "github_workflow_credential_posture_per_repo.csv", cred_repo_rows
     )
     print(
-        f"Wrote github_workflow_credential_posture_per_repo.csv"
-        f" ({cred_repo_count} rows)"
+        f"Wrote github_workflow_credential_posture_per_repo.csv "
+        f"({cred_repo_count} rows)"
     )
 
     oidc_only = sum(1 for f in all_credential_findings if f["posture"] == "oidc")
@@ -614,11 +676,11 @@ def main() -> None:
     print(f"No cloud auth detected: {no_cloud}")
     print(f"Could not load: {skipped}")
 
-    # ================================================================
-    # Stage 9: Analysing workflow trigger config risk
-    # ================================================================
 
-    # 9. Workflow trigger risk analysis
+def stage_9_trigger_risk_analysis(
+    client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
+) -> None:
+    """Stage 9: Analyse workflow trigger config risk."""
     print("\n--- Analysing workflow trigger risk ---")
 
     all_trigger_findings: List[Dict[str, Any]] = []
@@ -627,9 +689,8 @@ def main() -> None:
             client, row["owner"], row["repo_name"], row["path"]
         )
         all_trigger_findings.append(finding.model_dump())
-
         if (i + 1) % 100 == 0:
-            print(f"    Checked {i + 1} / {len(detail_rows)} workflow files")
+            print(f"  Checked {i + 1} / {len(detail_rows)} workflow files")
             time.sleep(0.1)
 
     trigger_count = CsvCompiler.write_rows(
@@ -682,7 +743,8 @@ def main() -> None:
         "github_workflow_trigger_risk_per_repo.csv", trigger_repo_rows
     )
     print(
-        f"Wrote github_workflow_trigger_risk_per_repo.csv ({trigger_summary_count} rows)"
+        f"Wrote github_workflow_trigger_risk_per_repo.csv "
+        f"({trigger_summary_count} rows)"
     )
 
     high_count = sum(1 for f in all_trigger_findings if f["risk_level"] == "high")
@@ -698,6 +760,74 @@ def main() -> None:
     print(f"Low risk: {low_count}")
     print(f"No risk: {no_risk_count}")
     print(f"Could not load: {could_not_load_count}")
+
+
+# --- Main orchestrator ----------------------------------------------------
+
+
+def _skip(stage_label: str, toggle_name: str) -> None:
+    print(
+        f"Skipping {stage_label}: {toggle_name} disabled in config",
+        file=sys.stderr,
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    config: AuditConfig = load_audit_config(args.config_file)
+    toggles = config.workflow_audit
+
+    client = GitHubHttpClient(auth_method=args.auth)
+    storage = SqliteRepoStorage(args.db)
+
+    # Stage 1 - mandatory
+    repo_list = stage_1_resolve_repo_list(args, client, config)
+
+    # Stage 2
+    if toggles.collect_baseline_data:
+        stage_2_collect_baseline(args, client, repo_list, storage)
+    else:
+        _skip("Stage 2", "collect_baseline_data")
+
+    # Stage 3
+    if toggles.collect_additional_data:
+        stage_3_collect_additional(args, client, repo_list, storage)
+    else:
+        _skip("Stage 3", "collect_additional_data")
+
+    # Stage 4 - always runs; reads from SQLite and produces detail_rows
+    # that later stages depend on. Cheap enough that a toggle adds no value.
+    repo_rows, detail_rows = stage_4_build_rows(repo_list, storage)
+
+    # Stage 5
+    if toggles.gen_posture_reports:
+        stage_5_write_posture_reports(args, repo_rows, detail_rows)
+    else:
+        _skip("Stage 5", "gen_posture_reports")
+
+    # Stage 6
+    if toggles.actions_analysis:
+        stage_6_actions_analysis(client, detail_rows)
+    else:
+        _skip("Stage 6", "actions_analysis")
+
+    # Stage 7
+    if toggles.permissions_analysis:
+        stage_7_permissions_analysis(client, detail_rows)
+    else:
+        _skip("Stage 7", "permissions_analysis")
+
+    # Stage 8
+    if toggles.credentials_analysis:
+        stage_8_credentials_analysis(client, detail_rows)
+    else:
+        _skip("Stage 8", "credentials_analysis")
+
+    # Stage 9
+    if toggles.trigger_risk_analysis:
+        stage_9_trigger_risk_analysis(client, detail_rows)
+    else:
+        _skip("Stage 9", "trigger_risk_analysis")
 
     print("--- Complete ---")
 

--- a/github_workflow.py
+++ b/github_workflow.py
@@ -298,7 +298,7 @@ def _parse_args() -> argparse.Namespace:
 # --- Stage functions ------------------------------------------------------
 
 
-def stage_1_resolve_repo_list(
+def resolve_repo_list(
     args: argparse.Namespace,
     client: GitHubHttpClient,
     config: AuditConfig,
@@ -344,7 +344,7 @@ def stage_1_resolve_repo_list(
     return repo_list
 
 
-def stage_2_collect_baseline(
+def collect_baseline(
     args: argparse.Namespace,
     client: GitHubHttpClient,
     repo_list: List[str],
@@ -363,7 +363,7 @@ def stage_2_collect_baseline(
     collector.collect(primary_org, repos=repo_list, resume=args.resume)
 
 
-def stage_3_collect_additional(
+def collect_additional(
     args: argparse.Namespace,
     client: GitHubHttpClient,
     repo_list: List[str],
@@ -399,7 +399,7 @@ def stage_3_collect_additional(
         )
 
 
-def stage_4_build_rows(
+def build_rows(
     repo_list: List[str], storage: SqliteRepoStorage
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Stage 4: Read collected data and build output row sets.
@@ -430,7 +430,7 @@ def stage_4_build_rows(
     return repo_rows, detail_rows
 
 
-def stage_5_write_posture_reports(
+def write_posture_reports(
     args: argparse.Namespace,
     repo_rows: List[Dict[str, Any]],
     detail_rows: List[Dict[str, Any]],
@@ -454,7 +454,7 @@ def stage_5_write_posture_reports(
     )
 
 
-def stage_6_actions_analysis(
+def actions_analysis(
     client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
 ) -> None:
     """Stage 6: Parse workflow files to inventory action usage + SHA pinning."""
@@ -561,7 +561,7 @@ def stage_6_actions_analysis(
     )
 
 
-def stage_7_permissions_analysis(
+def permissions_analysis(
     client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
 ) -> None:
     """Stage 7: Parse workflow files for permissions posture."""
@@ -597,7 +597,7 @@ def stage_7_permissions_analysis(
     print(f"Could not load: {skipped}")
 
 
-def stage_8_credentials_analysis(
+def credentials_analysis(
     client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
 ) -> None:
     """Stage 8: Assess OIDC vs long-lived credentials."""
@@ -677,7 +677,7 @@ def stage_8_credentials_analysis(
     print(f"Could not load: {skipped}")
 
 
-def stage_9_trigger_risk_analysis(
+def trigger_risk_analysis(
     client: GitHubHttpClient, detail_rows: List[Dict[str, Any]]
 ) -> None:
     """Stage 9: Analyse workflow trigger config risk."""
@@ -780,52 +780,52 @@ def main() -> None:
     client = GitHubHttpClient(auth_method=args.auth)
     storage = SqliteRepoStorage(args.db)
 
-    # Stage 1 - mandatory
-    repo_list = stage_1_resolve_repo_list(args, client, config)
+    # Stage 1 - resolve_repo_lis. (mandatory)
+    repo_list = resolve_repo_list(args, client, config)
 
-    # Stage 2
+    # Stage 2 - collect_baseline
     if toggles.collect_baseline_data:
-        stage_2_collect_baseline(args, client, repo_list, storage)
+        collect_baseline(args, client, repo_list, storage)
     else:
         _skip("Stage 2", "collect_baseline_data")
 
-    # Stage 3
+    # Stage 3 - collect_additional
     if toggles.collect_additional_data:
-        stage_3_collect_additional(args, client, repo_list, storage)
+        collect_additional(args, client, repo_list, storage)
     else:
         _skip("Stage 3", "collect_additional_data")
 
     # Stage 4 - always runs; reads from SQLite and produces detail_rows
     # that later stages depend on. Cheap enough that a toggle adds no value.
-    repo_rows, detail_rows = stage_4_build_rows(repo_list, storage)
+    repo_rows, detail_rows = build_rows(repo_list, storage)
 
-    # Stage 5
+    # Stage 5 - write_posture_reports
     if toggles.gen_posture_reports:
-        stage_5_write_posture_reports(args, repo_rows, detail_rows)
+        write_posture_reports(args, repo_rows, detail_rows)
     else:
         _skip("Stage 5", "gen_posture_reports")
 
-    # Stage 6
+    # Stage 6 - actions_analysis
     if toggles.actions_analysis:
-        stage_6_actions_analysis(client, detail_rows)
+        actions_analysis(client, detail_rows)
     else:
         _skip("Stage 6", "actions_analysis")
 
-    # Stage 7
+    # Stage 7 - permissions_analysis
     if toggles.permissions_analysis:
-        stage_7_permissions_analysis(client, detail_rows)
+        permissions_analysis(client, detail_rows)
     else:
         _skip("Stage 7", "permissions_analysis")
 
-    # Stage 8
+    # Stage 8 - credentials_analysis
     if toggles.credentials_analysis:
-        stage_8_credentials_analysis(client, detail_rows)
+        credentials_analysis(client, detail_rows)
     else:
         _skip("Stage 8", "credentials_analysis")
 
-    # Stage 9
+    # Stage 9 - trigger_risk_analysis
     if toggles.trigger_risk_analysis:
-        stage_9_trigger_risk_analysis(client, detail_rows)
+        trigger_risk_analysis(client, detail_rows)
     else:
         _skip("Stage 9", "trigger_risk_analysis")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for core.config."""
+
+import pytest
+import yaml
+
+from core.config import (
+    AuditConfig,
+    load_audit_config,
+)
+
+
+def test_defaults_all_stages_enabled():
+    config = AuditConfig()
+    audit = config.workflow_audit
+    assert audit.collect_baseline_data is True
+    assert audit.collect_additional_data is True
+    assert audit.gen_posture_reports is True
+    assert audit.actions_analysis is True
+    assert audit.permissions_analysis is True
+    assert audit.credentials_analysis is True
+    assert audit.trigger_risk_analysis is True
+    assert config.repo_list_file == "repo_list.yaml"
+
+
+def test_load_returns_defaults_when_default_path_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = load_audit_config()
+    assert config == AuditConfig()
+
+
+def test_load_raises_when_explicit_path_missing(tmp_path):
+    missing = tmp_path / "does_not_exist.yaml"
+    with pytest.raises(FileNotFoundError):
+        load_audit_config(missing)
+
+
+def test_load_respects_stage_toggles(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "repo_list_file": "custom_repos.yaml",
+                "workflow_audit": {
+                    "collect_baseline_data": True,
+                    "collect_additional_data": True,
+                    "gen_posture_reports": False,
+                    "actions_analysis": False,
+                    "permissions_analysis": False,
+                    "credentials_analysis": True,
+                    "trigger_risk_analysis": False,
+                },
+            }
+        )
+    )
+
+    config = load_audit_config(config_file)
+
+    assert config.repo_list_file == "custom_repos.yaml"
+    assert config.workflow_audit.gen_posture_reports is False
+    assert config.workflow_audit.actions_analysis is False
+    assert config.workflow_audit.credentials_analysis is True
+    assert config.workflow_audit.trigger_risk_analysis is False
+
+
+def test_load_fills_missing_fields_with_defaults(tmp_path):
+    config_file = tmp_path / "partial.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "workflow_audit": {
+                    "credentials_analysis": False,
+                }
+            }
+        )
+    )
+
+    config = load_audit_config(config_file)
+
+    assert config.repo_list_file == "repo_list.yaml"
+    assert config.workflow_audit.collect_baseline_data is True
+    assert config.workflow_audit.credentials_analysis is False
+
+
+def test_empty_yaml_returns_defaults(tmp_path):
+    config_file = tmp_path / "empty.yaml"
+    config_file.write_text("")
+    config = load_audit_config(config_file)
+    assert config == AuditConfig()

--- a/tests/test_repo_list_resolution.py
+++ b/tests/test_repo_list_resolution.py
@@ -1,0 +1,120 @@
+"""Unit tests for the repo list resolution order in github_workflow.stage_1."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import github_workflow
+from core.config import AuditConfig
+
+
+def _make_args(**overrides):
+    defaults = dict(
+        repos=None,
+        repo_file=None,
+        limit=500,
+        org="ministryofjustice",
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+def test_explicit_repos_arg_wins(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    args = _make_args(repos=["ministryofjustice/foo", "ministryofjustice/bar"])
+    config = AuditConfig()
+    client = MagicMock()
+
+    result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+
+    assert result == ["ministryofjustice/foo", "ministryofjustice/bar"]
+
+
+def test_repo_file_arg_used_when_no_repos(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo_file = tmp_path / "custom.yaml"
+    repo_file.write_text("repos:\n  - ministryofjustice/baz\n")
+
+    args = _make_args(repo_file=str(repo_file))
+    config = AuditConfig()
+    client = MagicMock()
+
+    with patch(
+        "github_workflow.load_repo_list_file",
+        return_value=["ministryofjustice/baz"],
+    ) as mock_load:
+        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+
+    mock_load.assert_called_once_with(str(repo_file))
+    assert result == ["ministryofjustice/baz"]
+
+
+def test_config_repo_list_file_used_when_no_cli_args(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_repo_file = tmp_path / "from_config.yaml"
+    config_repo_file.write_text("repos:\n  - ministryofjustice/qux\n")
+
+    args = _make_args()
+    config = AuditConfig(repo_list_file=str(config_repo_file))
+    client = MagicMock()
+
+    with patch(
+        "github_workflow.load_repo_list_file",
+        return_value=["ministryofjustice/qux"],
+    ) as mock_load:
+        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+
+    mock_load.assert_called_once_with(str(config_repo_file))
+    assert result == ["ministryofjustice/qux"]
+
+
+def test_default_repo_list_yaml_in_cwd_used_when_no_cli_or_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    default_file = tmp_path / "repo_list.yaml"
+    default_file.write_text("repos:\n  - ministryofjustice/default\n")
+
+    args = _make_args()
+    # repo_list_file in config points to a path that doesn't exist
+    config = AuditConfig(repo_list_file="/nonexistent/path.yaml")
+    client = MagicMock()
+
+    with patch(
+        "github_workflow.load_repo_list_file",
+        return_value=["ministryofjustice/default"],
+    ) as mock_load:
+        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+
+    mock_load.assert_called_once_with("repo_list.yaml")
+    assert result == ["ministryofjustice/default"]
+
+
+def test_falls_back_to_org_listing_when_nothing_else_available(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    args = _make_args()
+    config = AuditConfig(repo_list_file="/nonexistent/path.yaml")
+    client = MagicMock()
+
+    with patch(
+        "github_workflow.list_org_repos",
+        return_value=["ministryofjustice/from_api"],
+    ) as mock_list:
+        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+
+    mock_list.assert_called_once_with("ministryofjustice", client)
+    assert result == ["ministryofjustice/from_api"]
+
+
+def test_raises_when_org_listing_fails_and_no_other_source(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    args = _make_args()
+    config = AuditConfig(repo_list_file="/nonexistent/path.yaml")
+    client = MagicMock()
+
+    with patch(
+        "github_workflow.list_org_repos",
+        side_effect=Exception("API down"),
+    ):
+        with pytest.raises(SystemExit, match="Unable to list repos"):
+            github_workflow.stage_1_resolve_repo_list(args, client, config)

--- a/tests/test_repo_list_resolution.py
+++ b/tests/test_repo_list_resolution.py
@@ -25,7 +25,7 @@ def test_explicit_repos_arg_wins(tmp_path, monkeypatch):
     config = AuditConfig()
     client = MagicMock()
 
-    result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+    result = github_workflow.resolve_repo_list(args, client, config)
 
     assert result == ["ministryofjustice/foo", "ministryofjustice/bar"]
 
@@ -43,7 +43,7 @@ def test_repo_file_arg_used_when_no_repos(tmp_path, monkeypatch):
         "github_workflow.load_repo_list_file",
         return_value=["ministryofjustice/baz"],
     ) as mock_load:
-        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+        result = github_workflow.resolve_repo_list(args, client, config)
 
     mock_load.assert_called_once_with(str(repo_file))
     assert result == ["ministryofjustice/baz"]
@@ -62,7 +62,7 @@ def test_config_repo_list_file_used_when_no_cli_args(tmp_path, monkeypatch):
         "github_workflow.load_repo_list_file",
         return_value=["ministryofjustice/qux"],
     ) as mock_load:
-        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+        result = github_workflow.resolve_repo_list(args, client, config)
 
     mock_load.assert_called_once_with(str(config_repo_file))
     assert result == ["ministryofjustice/qux"]
@@ -84,7 +84,7 @@ def test_default_repo_list_yaml_in_cwd_used_when_no_cli_or_config(
         "github_workflow.load_repo_list_file",
         return_value=["ministryofjustice/default"],
     ) as mock_load:
-        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+        result = github_workflow.resolve_repo_list(args, client, config)
 
     mock_load.assert_called_once_with("repo_list.yaml")
     assert result == ["ministryofjustice/default"]
@@ -100,7 +100,7 @@ def test_falls_back_to_org_listing_when_nothing_else_available(tmp_path, monkeyp
         "github_workflow.list_org_repos",
         return_value=["ministryofjustice/from_api"],
     ) as mock_list:
-        result = github_workflow.stage_1_resolve_repo_list(args, client, config)
+        result = github_workflow.resolve_repo_list(args, client, config)
 
     mock_list.assert_called_once_with("ministryofjustice", client)
     assert result == ["ministryofjustice/from_api"]
@@ -117,4 +117,4 @@ def test_raises_when_org_listing_fails_and_no_other_source(tmp_path, monkeypatch
         side_effect=Exception("API down"),
     ):
         with pytest.raises(SystemExit, match="Unable to list repos"):
-            github_workflow.stage_1_resolve_repo_list(args, client, config)
+            github_workflow.resolve_repo_list(args, client, config)


### PR DESCRIPTION
# Introduction :pencil2:
Introduction :pencil2:
This PR Closes #110 — Define and publish a YAML config control for the audit scripts in moj-github-discovery.

It refactors github_workflow.py so each of its nine stages lives in its own dedicated function, then introduces a YAML-based config system that lets the user toggle individual stages on or off without commenting out code or running the full pipeline every time. This addresses the pain point Nathan and I raised during the #31 PR review where running just the OIDC credential check (Stage 8) required sitting through Stages 1–7 first.


## Resolution :heavy_check_mark:
Resolution :heavy_check_mark:
5 files changed, following the approved core architecture pattern.
config/audit_config.yaml (new)
• Default audit config shipping with the repo
• Holds global attributes (repo_list_file) and per-stage toggles under workflow_audit
• All stages default to true so existing behaviour is preserved when no config changes are made
• Covers all 9 stages including trigger_risk_analysis for Stage 9 added in #111


core/config.py (new)
• AuditConfig and WorkflowAuditConfig Pydantic models holding the schema
• load_audit_config() function with the following behaviour:
• If no path is passed, looks for config/audit_config.yaml; if missing, returns full defaults
• If an explicit path is passed but missing, raises FileNotFoundError rather than silently falling back
• Missing fields in the YAML fall back to model defaults so partial configs work
• Empty YAML files return defaults


github_workflow.py (modified)
• Each stage in main() extracted into its own dedicated function: 
stage_1_resolve_repo_list, 
stage_2_collect_baseline, 
stage_3_collect_additional, 
stage_4_build_rows, 
stage_5_write_posture_reports, 
stage_6_actions_analysis, 
stage_7_permissions_analysis, 
stage_8_credentials_analysis, stage_9_trigger_risk_analysis

• New --config-file CLI argument for tailored testing with custom configs
• New orchestrator at the bottom of main() that reads the config and skips stages whose toggle is false, with informative Skipping Stage X: <toggle> disabled in config messages
• stage_1_resolve_repo_list now follows Nathan’s requested resolution order: --repos arg → --repo-file arg → repo_list_file from config → repo_list.yaml in cwd → fall back to org listing
• stage_4_build_rows wraps storage.read in a try/except for sqlite3.OperationalError, so when Stages 2/3 are disabled before the cache is populated the script reports a graceful warning instead of crashing
• Stages 1 and 4 always run because Stage 1 is needed to know what to scan and Stage 4 is just in-memory reads from SQLite that every later stage depends on


tests/test_config.py (new)
• 6 tests covering: defaults, missing default path returns defaults, missing explicit path raises, stage toggles respected, partial YAML fills missing fields with defaults, empty YAML returns defaults
tests/test_repo_list_resolution.py (new)
• 6 tests covering the full repo list resolution chain: explicit --repos wins, --repo-file used when no repos, config repo_list_file used when no CLI args, default repo_list.yaml in cwd used when no CLI or config, falls back to org listing when nothing else available, raises SystemExit when org listing fails and no other source

List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:

Test results
All 304 tests pass (292 existing + 12 new from #110).
Smoke tests run end-to-end:
• Default config (all stages on, 5 repos): runs through all 9 stages cleanly
• Stage-8-only config (Stages 2/3/5/6/7/9 disabled): confirmed correct skip messages and only Stage 8 executes
• Custom repo_list.yaml resolution: confirmed Using repo list from config: repo_list.yaml message and 2 repos picked up from the YAML


• No new dependencies required (uses existing pyyaml and pydantic)
• Schema is forward-compatible — adding new toggles in future tickets only requires adding the field to WorkflowAuditConfig with a default of True
• Follows the same Pydantic + module-pattern Osanda established in the core refactor and that I followed for #105 and #111

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>
<img width="1025" height="777" alt="image" src="https://github.com/user-attachments/assets/0dd9712d-b0b8-414a-9198-987e1944a769" />

</details>