### PR TITLE
Dependabot Cleanup

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }} # Set in repo variables (Settings > Secrets and variables > Actions)
 
       - name: Install npm
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
@@ -88,7 +88,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install uv & Set Python
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv & Set Python
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.1.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
@@ -99,7 +99,7 @@ jobs:
         run: npm ci --ignore-scripts --omit=dev
 
       - name: ⚡️ SCA
-        uses: ministryofjustice/devsecops-actions/sca@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
+        uses: ministryofjustice/devsecops-actions/sca@87dc13c20e2bf541b8a77fa1320a04983b18846f6 # v1.6.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}" # Mandatory
           dependency-review-config-file: "./.github/dependency-review-config.yml" # Optional

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.1.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }} # Set in repo variables (Settings > Secrets and variables > Actions)
 
       - name: Install
         shell: bash

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -99,7 +99,7 @@ jobs:
         run: npm ci --ignore-scripts --omit=dev
 
       - name: ⚡️ SCA
-        uses: ministryofjustice/devsecops-actions/sca@87dc13c20e2bf541b8a77fa1320a04983b18846f6 # v1.6.0
+        uses: ministryofjustice/devsecops-actions/sca@7dc13c20e2bf541b8a77fa1320a04983b18846f6 # v1.6.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}" # Mandatory
           dependency-review-config-file: "./.github/dependency-review-config.yml" # Optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,17 @@
       "name": "moj-github-discovery",
       "version": "1.0.0",
       "devDependencies": {
-        "cspell": "^9.7.0",
-        "markdownlint-cli2": "^0.22.0"
+        "cspell": "^10.0.0",
+        "markdownlint-cli2": "^0.22.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.7.0.tgz",
-      "integrity": "sha512-s7h1vo++Q3AsfQa3cs0u/KGwm3SYInuIlC4kjlCBWjQmb4KddiZB5O1u0+3TlA7GycHb5M4CR7MDfHUICgJf+w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.0.tgz",
+      "integrity": "sha512-ci410HEkng2582oOjlRHQtlGXwh+rUC/mVcN9dObLHpKhvPgzn2S6vT56pARstxxZpcCUG/oLhn3dCqdJlVzmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26,54 +26,54 @@
         "@cspell/dict-al": "^1.1.1",
         "@cspell/dict-aws": "^4.0.17",
         "@cspell/dict-bash": "^4.2.2",
-        "@cspell/dict-companies": "^3.2.10",
+        "@cspell/dict-companies": "^3.2.11",
         "@cspell/dict-cpp": "^7.0.2",
         "@cspell/dict-cryptocurrencies": "^5.0.5",
         "@cspell/dict-csharp": "^4.0.8",
-        "@cspell/dict-css": "^4.0.19",
+        "@cspell/dict-css": "^4.1.1",
         "@cspell/dict-dart": "^2.3.2",
         "@cspell/dict-data-science": "^2.0.13",
         "@cspell/dict-django": "^4.1.6",
         "@cspell/dict-docker": "^1.1.17",
-        "@cspell/dict-dotnet": "^5.0.12",
+        "@cspell/dict-dotnet": "^5.0.13",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.29",
+        "@cspell/dict-en_us": "^4.4.33",
         "@cspell/dict-en-common-misspellings": "^2.1.12",
-        "@cspell/dict-en-gb-mit": "^3.1.18",
-        "@cspell/dict-filetypes": "^3.0.15",
+        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-filetypes": "^3.0.18",
         "@cspell/dict-flutter": "^1.1.1",
-        "@cspell/dict-fonts": "^4.0.5",
+        "@cspell/dict-fonts": "^4.0.6",
         "@cspell/dict-fsharp": "^1.1.1",
-        "@cspell/dict-fullstack": "^3.2.8",
+        "@cspell/dict-fullstack": "^3.2.9",
         "@cspell/dict-gaming-terms": "^1.1.2",
         "@cspell/dict-git": "^3.1.0",
         "@cspell/dict-golang": "^6.0.26",
         "@cspell/dict-google": "^1.0.9",
         "@cspell/dict-haskell": "^4.0.6",
-        "@cspell/dict-html": "^4.0.14",
+        "@cspell/dict-html": "^4.0.15",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-java": "^5.0.12",
         "@cspell/dict-julia": "^1.1.1",
         "@cspell/dict-k8s": "^1.0.12",
         "@cspell/dict-kotlin": "^1.1.1",
-        "@cspell/dict-latex": "^5.0.0",
+        "@cspell/dict-latex": "^5.1.0",
         "@cspell/dict-lorem-ipsum": "^4.0.5",
         "@cspell/dict-lua": "^4.0.8",
         "@cspell/dict-makefile": "^1.0.5",
-        "@cspell/dict-markdown": "^2.0.14",
+        "@cspell/dict-markdown": "^2.0.16",
         "@cspell/dict-monkeyc": "^1.0.12",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.34",
+        "@cspell/dict-npm": "^5.2.38",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
-        "@cspell/dict-public-licenses": "^2.0.15",
-        "@cspell/dict-python": "^4.2.25",
+        "@cspell/dict-public-licenses": "^2.0.16",
+        "@cspell/dict-python": "^4.2.26",
         "@cspell/dict-r": "^2.1.1",
-        "@cspell/dict-ruby": "^5.1.0",
+        "@cspell/dict-ruby": "^5.1.1",
         "@cspell/dict-rust": "^4.1.2",
         "@cspell/dict-scala": "^5.0.9",
         "@cspell/dict-shell": "^1.1.2",
-        "@cspell/dict-software-terms": "^5.1.21",
+        "@cspell/dict-software-terms": "^5.2.2",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
@@ -83,86 +83,86 @@
         "@cspell/dict-zig": "^1.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.7.0.tgz",
-      "integrity": "sha512-6xpGXlMtQA3hV2BCAQcPkpx9eI12I0o01i9eRqSSEDKtxuAnnrejbcCpL+5OboAjTp3/BSeNYSnhuWYLkSITWQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.0.tgz",
+      "integrity": "sha512-hq5dui2ngYMZKbBauX7K1tkqlu81sX/uaCO49ZJLPjeZsE1auZLtHehDLfAr/ZXoj/dLYeQMSKiaJyE+qLVPHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.7.0.tgz",
-      "integrity": "sha512-w1PZIFXuvjnC6mQHyYAFnrsn5MzKnEcEkcK1bj4OG00bAt7WX2VUA/eNNt9c1iHozCQ+FcRYlfbGxuBmNyzSgw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.0.tgz",
+      "integrity": "sha512-2vMh2pLt2dg/ArYvWjMP4v9HCm0pRhONsEJyc8oHdZyOYvX7trixX894I0M39+VBf3yWtPCEgYRh1UDXNIZRig==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.7.0.tgz",
-      "integrity": "sha512-iiisyRpJciU9SOHNSi0ZEK0pqbEMFRatI/R4O+trVKb+W44p4MNGClLVRWPGUmsFbZKPJL3jDtz0wPlG0/JCZA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.0.tgz",
+      "integrity": "sha512-qcgHhQvtEX8LSwIVsWrdUgiGim52lN3jT+ghlkdp72v+nBcGKsS2frEKTmbGLug+xcqppkzs6Q6VmsFp1MGtfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.7.0.tgz",
-      "integrity": "sha512-uiEgS238mdabDnwavo6HXt8K98jlh/jpm7NONroM9NTr9rzck2VZKD2kXEj85wDNMtRsRXNoywTjwQ8WTB6/+w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.0.tgz",
+      "integrity": "sha512-8H+IUDB7SmrpcRugQ5f55qG81ZShk6nQRk+natLz41TEY98D8/LCmjHEkh/vhDPph9pVJmNUp7JcM2E1UHEa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "global-directory": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.7.0.tgz",
-      "integrity": "sha512-fkqtaCkg4jY/FotmzjhIavbXuH0AgUJxZk78Ktf4XlhqOZ4wDeUWrCf220bva4mh3TWiLx/ae9lIlpl59Vx6hA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.0.tgz",
+      "integrity": "sha512-V7eigqg/TOoKwNK4Q18wr9KGxA8U5SFcoWVS8RyAxv4mQ+yNKHhvHEbRBifjPbQDer66afOrclb2UbqkIy2SOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.7.0.tgz",
-      "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.0.tgz",
+      "integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.7.0.tgz",
-      "integrity": "sha512-cjEApFF0aOAa1vTUk+e7xP8ofK7iC7hsRzj1FmvvVQz8PoLWPRaq+1bT89ypPsZQvavqm5sIgb97S60/aW4TVg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.0.tgz",
+      "integrity": "sha512-V5bjMldNksilnja3fu8muQmkW5/guyua1yNVOhoE2r7othSvjuDlGMl8g2bQSrWjp+UXu0dP/BEZ6JC/IfNwTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "9.7.0"
+        "cspell-lib": "10.0.0"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/dict-ada": {
@@ -260,9 +260,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.12.tgz",
-      "integrity": "sha512-FiV934kNieIjGTkiApu/WKvLYi/KBpvfWB2TSqpDQtmXZlt3uSa5blwblO1ZC8OvjH8RCq/31H5IdEYmTaZS7A==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
       "dev": true,
       "license": "MIT"
     },
@@ -274,9 +274,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.31.tgz",
-      "integrity": "sha512-MdV6mbrSkyIqn9+6F5poCyHIPqWB3H/wlDL9LXfjgAxNFBdYRE767xJtIYunzUqhUiJHSJgZajEFdTtMDw441Q==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.33.tgz",
+      "integrity": "sha512-zWftVqfUStDA37wO1ZNDN1qMJOfcxELa8ucHW8W8wBAZY3TK5Nb6deLogCK/IJi/Qljf30dwwuqqv84Qqle9Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -288,16 +288,16 @@
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.20.tgz",
-      "integrity": "sha512-rcWEKb1mwgK13CSHu6GwwFA/sWLRkB0twTzSfPxUOULJkhcUrL93ixohk416SBa0BVxixub+lOpTXKcCTbTXsA==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.22.tgz",
+      "integrity": "sha512-xE5Vg6gGdMkZ1Ep6z9SJMMioGkkT1GbxS5Mm0U3Ey1/H68P0G7cJcyiVr1CARxFbLqKE4QUpoV1o6jz1Z5Yl9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.17.tgz",
-      "integrity": "sha512-6f1gZf9o60fGQXGi/fZaryISUNDRmmJwGyr4QU1UvgUgOdpDHLVJtv/0wSL9q5F0wAkYhbXo/fNG8CcUTaf7Ww==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.18.tgz",
+      "integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -323,9 +323,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.8.tgz",
-      "integrity": "sha512-J6EeoeThvx/DFrcA2rJiCA6vfqwJMbkG0IcXhlsmRZmasIpanmxgt90OEaUazbZahFiuJT8wrhgQ1QgD1MsqBw==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.9.tgz",
+      "integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -462,9 +462,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.37",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.37.tgz",
-      "integrity": "sha512-dYKrD0bI08YgebJcbjsIDpTMK6EH0wTkEyQLsaH0T4tmsLJE95coTYb3eE7giRRGJADvBqrjH4fz5+INd85QqQ==",
+      "version": "5.2.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.38.tgz",
+      "integrity": "sha512-21ucGRPYYhr91C2cDBoMPTrcIOStQv33xOqJB0JLoC5LAs2Sfj9EoPGhGb+gIFVHz6Ia7JQWE2SJsOVFJD1wmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -490,9 +490,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.25.tgz",
-      "integrity": "sha512-hDdN0YhKgpbtZVRjQ2c8jk+n0wQdidAKj1Fk8w7KEHb3YlY5uPJ0mAKJk7AJKPNLOlILoUmN+HAVJz+cfSbWYg==",
+      "version": "4.2.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.26.tgz",
+      "integrity": "sha512-hbjN6BjlSgZOG2dA2DtvYNGBM5Aq0i0dHaZjMOI9K/9vRicVvKbcCiBSSrR3b+jwjhQL5ff7HwG5xFaaci0GQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -535,9 +535,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.0.tgz",
-      "integrity": "sha512-jyucc8KKxH5ClC4FPICISgcKAZU7UwgFdPkuuuK5nYIw0+l1umnUSn9IKCcOaurvXujvVP6mBfclXpUtmT6Vrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
+      "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -591,57 +591,57 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.7.0.tgz",
-      "integrity": "sha512-Ws36IYvtS/8IN3x6K9dPLvTmaArodRJmzTn2Rkf2NaTnIYWhRuFzsP3SVVO59NN3fXswAEbmz5DSbVUe8bPZHg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.0.tgz",
+      "integrity": "sha512-fMqu/5Ma1Q5ZCR/Par+Q4pvaTKmx5pKZzQmkwld2hNounVdk2OaIPM9MzpNn6I1mLk5J+wTnIZmfcWNAzNP9aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
+        "@cspell/url": "10.0.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.7.0.tgz",
-      "integrity": "sha512-Ln9e/8wGOyTeL3DCCs6kwd18TSpTw3kxsANjTrzLDASrX4cNmAdvc9J5dcIuBHPaqOAnRQxuZbzUlpRh73Y24w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.0.tgz",
+      "integrity": "sha512-UP57j9yrDtlCHpFxc/eGho1m8DP5olfu9KRWwd5fiqL9nMSE2rUJtPzQyvqmDwO5bVZt3B+fTVdo4gxuiqw25A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.7.0.tgz",
-      "integrity": "sha512-VnZ4ABgQeoS4RwofcePkDP7L6tf3Kh5D7LQKoyRM4R6XtfSsYefym6XKaRl3saGtthH5YyjgNJ0Tgdjen4wAAw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.0.tgz",
+      "integrity": "sha512-QrpOZMwz2pAjvl6Hky2PauYoMpLCASn3osjn7uKUbgFV70sahyj6tmx4rRgRX7vHu2WQLZev+YsuO4EujiBDOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.7.0.tgz",
-      "integrity": "sha512-5xbvDASjklrmy88O6gmGXgYhpByCXqOj5wIgyvwZe2l83T1bE+iOfGI4pGzZJ/mN+qTn1DNKq8BPBPtDgb7Q2Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.0.tgz",
+      "integrity": "sha512-JRsato0s2IjYdsng+AGL6oAqgZVQgih5aWKdmxs21H6EdhMaoFDmRE5kXm/RT5a6OMdtnzQM9DqeToqBChWIOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.7.0.tgz",
-      "integrity": "sha512-ZaaBr0pTvNxmyUbIn+nVPXPr383VqJzfUDMWicgTjJIeo2+T2hOq2kNpgpvTIrWtZrsZnSP8oXms1+sKTjcvkw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.0.tgz",
+      "integrity": "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -766,16 +766,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -838,23 +828,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/clear-module": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
-      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^2.0.0",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -880,31 +853,31 @@
       }
     },
     "node_modules/cspell": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.7.0.tgz",
-      "integrity": "sha512-ftxOnkd+scAI7RZ1/ksgBZRr0ouC7QRKtPQhD/PbLTKwAM62sSvRhE1bFsuW3VKBn/GilWzTjkJ40WmnDqH5iQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.0.tgz",
+      "integrity": "sha512-R25gsSR1SLlcGyw48fwJwp0PjXrVdl7RDO/Dm5+s4DvC1uQSlyiUxsr/8ZtbyC/MPeUJFQN9B4luqLlSm0WelQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/cspell-worker": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/url": "9.7.0",
+        "@cspell/cspell-json-reporter": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/cspell-worker": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/url": "10.0.0",
         "ansi-regex": "^6.2.2",
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "commander": "^14.0.3",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-gitignore": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-lib": "9.7.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-gitignore": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-lib": "10.0.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "semver": "^7.7.4",
         "tinyglobby": "^0.2.15"
       },
@@ -913,155 +886,154 @@
         "cspell-esm": "bin.mjs"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.7.0.tgz",
-      "integrity": "sha512-pguh8A3+bSJ1OOrKCiQan8bvaaY125de76OEFz7q1Pq309lIcDrkoL/W4aYbso/NjrXaIw6OjkgPMGRBI/IgGg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.0.tgz",
+      "integrity": "sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0",
-        "comment-json": "^4.5.1",
-        "smol-toml": "^1.6.0",
-        "yaml": "^2.8.2"
+        "@cspell/cspell-types": "10.0.0",
+        "comment-json": "^4.6.2",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.7.0.tgz",
-      "integrity": "sha512-k/Wz0so32+0QEqQe21V9m4BNXM5ZN6lz3Ix/jLCbMxFIPl6wT711ftjOWIEMFhvUOP0TWXsbzcuE9mKtS5mTig==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.0.tgz",
+      "integrity": "sha512-KubSoEAJO+77KPSSWjoLCz0+MIWVNq3joGTSyxucAZrBSJD64Y1O4BHHr1aj6XHIZwXhWWNScQlrQR3OcIulng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "fast-equals": "^6.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.7.0.tgz",
-      "integrity": "sha512-MtoYuH4ah4K6RrmaF834npMcRsTKw0658mC6yvmBacUQOmwB/olqyuxF3fxtbb55HDb7cXDQ35t1XuwwGEQeZw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.0.tgz",
+      "integrity": "sha512-55XLH9Y52eR7QgyV28Uaw8V9cN1YZ3PQIyrN9YBR4ndQNBKJxO9+jX1nwSspwnccCZiE/N+GGxFzRBb75JDSCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0"
+        "@cspell/url": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.7.0.tgz",
-      "integrity": "sha512-LUeAoEsoCJ+7E3TnUmWBscpVQOmdwBejMlFn0JkXy6LQzxrybxXBKf65RSdIv1o5QtrhQIMa358xXYQG0sv/tA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.0.tgz",
+      "integrity": "sha512-bXS35fMcA9X7GEkfnWBfoPd/vTnxxfXW+YHt6tWxu5fejfs00qUbjWp1oLC9FxRaXWxIkfsYp2mi1k1jYl4RVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "picomatch": "^4.0.3"
+        "@cspell/url": "10.0.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.7.0.tgz",
-      "integrity": "sha512-oEYME+7MJztfVY1C06aGcJgEYyqBS/v/ETkQGPzf/c6ObSAPRcUbVtsXZgnR72Gru9aBckc70xJcD6bELdoWCA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.0.tgz",
+      "integrity": "sha512-49udtYzkcCYEIDJbFOb4IwiAJebOYZnYvG6o6Ep19Tq0Xwjk7i4vxUprNiFNDCWFbcbJRPE9cpwQUVwp5WFGLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.7.0.tgz",
-      "integrity": "sha512-V7x0JHAUCcJPRCH8c0MQkkaKmZD2yotxVyrNEx2SZTpvnKrYscLEnUUTWnGJIIf9znzISqw116PLnYu2c+zd6Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.0.tgz",
+      "integrity": "sha512-NQCAUhx9DwKApxPuFl7EK1K1XSaQEAPld45yjjwv93xF8rJkEGkgzOwjbqafwAD20eKYv1a7oj/9EC0S5jETSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.7.0",
-        "@cspell/url": "9.7.0"
+        "@cspell/cspell-service-bus": "10.0.0",
+        "@cspell/url": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.7.0.tgz",
-      "integrity": "sha512-aTx/aLRpnuY1RJnYAu+A8PXfm1oIUdvAQ4W9E66bTgp1LWI+2G2++UtaPxRIgI0olxE9vcXqUnKpjOpO+5W9bQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.0.tgz",
+      "integrity": "sha512-PowW6JEjuv/F2aFEirZvBxpzHdchOnpsUJbeIcFcai0++taLTbHQObROBEBf7e0S8DnHpVD5TZkqrTME5e44wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-resolver": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/filetypes": "9.7.0",
-        "@cspell/rpc": "9.7.0",
-        "@cspell/strong-weak-map": "9.7.0",
-        "@cspell/url": "9.7.0",
-        "clear-module": "^4.1.2",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-grammar": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "@cspell/cspell-bundled-dicts": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-resolver": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/filetypes": "10.0.0",
+        "@cspell/rpc": "10.0.0",
+        "@cspell/strong-weak-map": "10.0.0",
+        "@cspell/url": "10.0.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-grammar": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
-        "import-fresh": "^3.3.1",
+        "import-fresh": "^4.0.0",
         "resolve-from": "^5.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.1.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.7.0.tgz",
-      "integrity": "sha512-a2YqmcraL3g6I/4gY7SYWEZfP73oLluUtxO7wxompk/kOG2K1FUXyQfZXaaR7HxVv10axT1+NrjhOmXpfbI6LA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.0.tgz",
+      "integrity": "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "10.0.0"
       }
     },
     "node_modules/debug": {
@@ -1297,20 +1269,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/global-directory/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1339,43 +1301,16 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
       "engines": {
-        "node": ">=6"
+        "node": ">=22.15"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -1387,6 +1322,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -1606,13 +1551,13 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.0.tgz",
-      "integrity": "sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.1.1",
+        "globby": "16.2.0",
         "js-yaml": "4.1.1",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
@@ -1620,7 +1565,7 @@
         "markdownlint": "0.40.0",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8",
-        "smol-toml": "1.6.0"
+        "smol-toml": "1.6.1"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
@@ -1643,19 +1588,6 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
-      }
-    },
-    "node_modules/markdownlint-cli2/node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/mdurl": {
@@ -2245,19 +2177,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parent-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
-      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2517,9 +2436,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "spellcheck": "cspell '**/*' --no-progress --show-suggestions"
   },
   "devDependencies": {
-    "cspell": "^9.7.0",
-    "markdownlint-cli2": "^0.22.0"
+    "cspell": "^10.0.0",
+    "markdownlint-cli2": "^0.22.1"
   },
   "cspell": {
     "allowCompoundWords": true,


### PR DESCRIPTION
# Introduction :pencil2:

Covers off dependabot updates to github actions and NPM dependencies

## Resolution :heavy_check_mark:

- dependency-review-action updated to v5.0.0 #123 
- devsecops-actions v1.5.0 -> v1.6.0 #122 
- setup-uv v8.0.0 -> v8.1.0 #108 

- markdownlint-cli2 -> v0.22.1 #112 
- cspell -> v10.0.0 #76 