### PR TITLE
Extend YAML Config Support: list_repos.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,16 @@ uv run python scripts/list_repos.py --repo-file <file> [options]
 
 **Options:**
 
+- `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
+
+**Options: CLI Overrides:**
+
 - `--repo-file <file>` - Repositories to audit. Preferred format is YAML (`repos:` list of `owner/repo` strings) and comments are supported.
-- `--db <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
-- `--excel <path>` - Export results to Excel file. Requires `openpyxl`.
+- `--db-path <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
+- `--output-filename <path>` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
 - `--limit <N>` - Crop the loaded `--repo-file` list to the first N entries before collection.
-- `--sort [-]column` - Sort by repo field (`-` prefix for descending). Defaults to last updated (`pushed_at` desc).
+- `--sort-by [-]column` - Sort by repo field (`-` prefix for descending). Defaults to last updated (`pushed_at` desc).
+- `--sort-ascending <true/false>` - Sort order for `--sort-by` field, defaults to `false` / descending
 - `--standard-endpoints` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
 - `--resume` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 - `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ collection, storage, and report shaping.
 - Register endpoint classes in the endpoint registries consumed by collectors.
 - Keep output shaping in `core/presenters.py` and data enrichment in `core/transforms.py`.
 - Add focused unit tests first (`tests/test_github_api.py`, `tests/test_collector.py`, `tests/test_presenters.py`, `tests/test_transforms.py`).
+- Add any script-specific config to `config/audit-config.yaml` with a corresponding model in `core/config.py`
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ collection, storage, and report shaping.
 - Register endpoint classes in the endpoint registries consumed by collectors.
 - Keep output shaping in `core/presenters.py` and data enrichment in `core/transforms.py`.
 - Add focused unit tests first (`tests/test_github_api.py`, `tests/test_collector.py`, `tests/test_presenters.py`, `tests/test_transforms.py`).
-- Add any script-specific config to `config/audit-config.yaml` with a corresponding model in `core/config.py`
+- Add any script-specific config to `config/audit_config.yaml` with a corresponding model in `core/config.py`
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ collection, storage, and report shaping.
 - Register endpoint classes in the endpoint registries consumed by collectors.
 - Keep output shaping in `core/presenters.py` and data enrichment in `core/transforms.py`.
 - Add focused unit tests first (`tests/test_github_api.py`, `tests/test_collector.py`, `tests/test_presenters.py`, `tests/test_transforms.py`).
-- Add any script-specific config to `config/audit_config.yaml` with a corresponding model in `core/config.py`
+- Add any script-specific config to `config/audit_config.yaml` with a corresponding model in `core/config.py`.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -79,42 +79,16 @@ the core SQLite storage, and optionally exports an Excel workbook.
 uv run python scripts/list_repos.py --repo-file <file> [options]
 ```
 
-**Options:**
+**CLI Options:**
 
 - `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
-
-**Options: CLI Overrides:**
-
-- `--repo-file <file>` - Repositories to audit. Preferred format is YAML (`repos:` list of `owner/repo` strings) and comments are supported.
-- `--db-path <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
-- `--output-filename <path>` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
-- `--limit <N>` - Crop the loaded `--repo-file` list to the first N entries before collection.
-- `--sort-by [-]column` - Sort by repo field (`-` prefix for descending). Defaults to last updated (`pushed_at` desc).
-- `--sort-ascending <true/false>` - Sort order for `--sort-by` field, defaults to `false` / descending
-- `--standard-endpoints` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
-- `--resume` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 - `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.
 
 **Examples:**
 
 ```bash
-# Audit all repos from file and print JSON output
-uv run python scripts/list_repos.py --repo-file repo_list.yaml
-
-# Audit all repos from file and print JSON output, authenticating via PAT specifically
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --auth pat
-
-# Export to Excel
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --excel report.xlsx
-
-# Limit processing to first 50 repos in file
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --limit 50
-
-# Use a custom core storage database path
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --db /tmp/audit.db
-
-# Sort output by stars ascending
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --sort +stargazers
+# Audit all repos from file
+uv run python scripts/list_repos.py --config-file config/audit_config.yaml --auth app
 ```
 
 ### 2. `archive_repos.py` - Find Archive Candidates

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ collection, storage, and report shaping.
 - Add focused unit tests first (`tests/test_github_api.py`, `tests/test_collector.py`, `tests/test_presenters.py`, `tests/test_transforms.py`).
 - Add any script-specific config to `config/audit_config.yaml` with a corresponding model in `core/config.py`.
 
+## Global Config Attributes
+
+- `github_organization` - The GitHub organisation for the scripts to run against - default `ministryofjustice`
+- `repo_list_file` - Path to the repo list YAML file to be referenced by the scripts - defaults to `repo_list.yaml` at project root.
+
 ## Scripts
 
 ### 1. `list_repos.py` - Audit Repositories From a File
@@ -83,6 +88,16 @@ uv run python scripts/list_repos.py --repo-file <file> [options]
 
 - `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
 - `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.
+
+**Config Parameters:**
+
+- `database_path: <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
+- `output-filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
+- `repo_limit: <N>` - Crop the loaded `repo_list_file` list to the first N entries before collection - ideal for adhoc quick checks.
+- `resume: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
+- `standard_endpoints_only: true/false` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
+- `sort_by_field: <column>` - Sort by repo field. Defaults to last updated (`pushed_at`).
+- `sort_ascending: <true/false>` - Sort order for `sort_by` field, defaults to `false` / descending
 
 **Examples:**
 

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -11,7 +11,7 @@ list_repos:
   output_filename: "list_repos.xlsx"
   repo_limit: 50
   resume: true
-  standard_endpoints: true
+  standard_endpoints_only: true
   sort_by_field: "pushed_at"
   sort_ascending: false
 

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -2,18 +2,17 @@
 # Override by passing --config-file path/to/your.yaml on the CLI.
 
 # Global attributes used by all/multiple scripts
-github_organisation: "ministryofjustice"
+github_organization: "ministryofjustice"
 repo_list_file: "repo_list.yaml"
 
 # Stage Toggles for list_repos.py.
-
 list_repos:
-  database_file: "repo_audit.db"
-  output_file_format: "excel"
+  database_path: "internal/repo_audit.db"
+  output_filename: "list_repos.xlsx"
   repo_limit: 400
   resume: true
   sort_by_field: "pushed_at"
-  sort_order: "descending"
+  sort_ascending: false
 
 # Stage toggles for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -5,7 +5,7 @@
 github_organization: "ministryofjustice"
 repo_list_file: "repo_list.yaml"
 
-# Stage Toggles for list_repos.py.
+# Script config for list_repos.py.
 list_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "list_repos.xlsx"
@@ -14,7 +14,7 @@ list_repos:
   sort_by_field: "pushed_at"
   sort_ascending: false
 
-# Stage toggles for github_workflow.py.
+# Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,
 # so disabling them only makes sense when a previous run has already
 # populated the SQLite cache (default: github_workflow_posture.db).

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -2,7 +2,6 @@
 # Override by passing --config-file path/to/your.yaml on the CLI.
 
 # Global attributes used by all/multiple scripts
-authentication_method: "app"
 github_organisation: "ministryofjustice"
 repo_list_file: "repo_list.yaml"
 

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -9,10 +9,12 @@ repo_list_file: "repo_list.yaml"
 list_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "list_repos.xlsx"
-  repo_limit: 400
+  repo_limit: 50
   resume: true
+  standard_endpoints: true
   sort_by_field: "pushed_at"
   sort_ascending: false
+
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -1,8 +1,20 @@
 # Default audit config for moj-github-discovery scripts.
 # Override by passing --config-file path/to/your.yaml on the CLI.
 
-# Global attributes used by all scripts
+# Global attributes used by all/multiple scripts
+authentication_method: "app"
+github_organisation: "ministryofjustice"
 repo_list_file: "repo_list.yaml"
+
+# Stage Toggles for list_repos.py.
+
+list_repos:
+  database_file: "repo_audit.db"
+  output_file_format: "excel"
+  repo_limit: 400
+  resume: true
+  sort_by_field: "pushed_at"
+  sort_order: "descending"
 
 # Stage toggles for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/core/config.py
+++ b/core/config.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-import sys
 import yaml
 from pydantic import BaseModel, Field
 
@@ -54,26 +53,18 @@ class AuditConfig(BaseModel):
 
 
 def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
-    """Load an :class:`AuditConfig` from disk.
+    if config_path is not None:
+        # Explicit override via CLI - must exist if provided
+        if not config_path.exists():
+            raise FileNotFoundError(f"Config file not found at {config_path}")
+        resolved_path = config_path
+    else:
+        # No CLI override - fall back to default config file, then defaults if not found
+        resolved_path = DEFAULT_CONFIG_PATH
+        if not resolved_path.exists():
+            return AuditConfig()  # return defaults if no config file found
 
-    Behaviour:
-
-    - If the file at ``config_path`` exists, it will be loaded and parsed as YAML.
-    - If the file does not exist and ``config_path`` is the default path, a warning will be printed and a default config will be returned.
-    - If the file does not exist and ``config_path`` is not the default path, a FileNotFoundError will be raised.
-    """
-    resolved_path = config_path or DEFAULT_CONFIG_PATH
-
-    if not resolved_path.exists():
-        print(
-            f"Warning: Config file not found at {resolved_path}. "
-            "Using default config values. To fix this, create a config file at the default location or specify a path with --config-file.",
-            file=sys.stderr,
-        )
-        return AuditConfig()
-
-    print(f"Reading config from {resolved_path}...", file=sys.stderr)
-    with resolved_path.open("r", encoding="utf-8") as fh:
-        config_data = yaml.safe_load(fh) or {}
+    with resolved_path.open() as fh:
+        config_data = yaml.safe_load(fh) or {}  # handle empty file case gracefully
 
     return AuditConfig(**config_data)

--- a/core/config.py
+++ b/core/config.py
@@ -20,7 +20,9 @@ DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 class ListReposConfig(BaseModel):
     """Config for ``list_repos.py`` script."""
 
-    database_filename: str = "repo_audit.db"  # SQLite cache file for repo audit data
+    database_path: str = (
+        "internal/repo_audit.db"  # SQLite cache file for repo audit data
+    )
     output_filename: str = "list_repos.xlsx"  # output file for repo summary data
     repo_limit: Optional[int] = 400
     resume: bool = (

--- a/core/config.py
+++ b/core/config.py
@@ -14,6 +14,21 @@ import sys
 import yaml
 from pydantic import BaseModel, Field
 
+DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
+
+
+class ListReposConfig(BaseModel):
+    """Config for ``list_repos.py`` script."""
+
+    database_filename: str = "repo_audit.db"  # SQLite cache file for repo audit data
+    output_filename: str = "list_repos.xlsx"  # output file for repo summary data
+    repo_limit: Optional[int] = 400
+    resume: bool = (
+        True  # whether to use database cache to skip endpoints already collected
+    )
+    sort_by_field: str = "pushed_at"  # field to sort by
+    sort_ascending: bool = False  # sort order - descending by default
+
 
 class WorkflowAuditConfig(BaseModel):
     """Per-stage toggles for ``github_workflow.py``."""
@@ -30,11 +45,10 @@ class WorkflowAuditConfig(BaseModel):
 class AuditConfig(BaseModel):
     """Top-level audit config loaded from ``audit_config.yaml``."""
 
+    github_organization: str = "ministryofjustice"
     repo_list_file: str = "repo_list.yaml"
+    list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
     workflow_audit: WorkflowAuditConfig = Field(default_factory=WorkflowAuditConfig)
-
-
-DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 
 
 def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
@@ -42,33 +56,22 @@ def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
 
     Behaviour:
 
-    * If ``config_path`` is ``None``, the function looks for the default
-      file at ``config/audit_config.yaml``. If that file is missing, a
-      fully-defaulted :class:`AuditConfig` is returned (all stages on).
-    * If ``config_path`` is provided but the file does not exist, a
-      :class:`FileNotFoundError` is raised — the caller asked for a
-      specific file and we should not silently fall back.
-    * Missing fields in the YAML fall back to model defaults, so a
-      partial config only needs to list the toggles being changed.
+    - If the file at ``config_path`` exists, it will be loaded and parsed as YAML.
+    - If the file does not exist and ``config_path`` is the default path, a warning will be printed and a default config will be returned.
+    - If the file does not exist and ``config_path`` is not the default path, a FileNotFoundError will be raised.
     """
-    if config_path is None:
+    resolved_path = config_path or DEFAULT_CONFIG_PATH
+
+    if not resolved_path.exists():
         print(
-            f"No config file specified, looking for default at {DEFAULT_CONFIG_PATH}...",
+            f"Warning: Config file not found at {resolved_path}. "
+            "Using default config values. To fix this, create a config file at the default location or specify a path with --config-file.",
             file=sys.stderr,
         )
-        resolved = DEFAULT_CONFIG_PATH
-        if not resolved.exists():
-            print(f"Default config file not found: {resolved}", file=sys.stderr)
-            return AuditConfig()
-    else:
-        print(f"Loading config from {config_path}...", file=sys.stderr)
-        resolved = Path(config_path)
-        if not resolved.exists():
-            print(f"Config file not found: {resolved}", file=sys.stderr)
-            raise FileNotFoundError(f"Config file not found: {resolved}")
+        return AuditConfig()
 
-    print(f"Reading config from {resolved}...", file=sys.stderr)
-    with resolved.open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    print(f"Reading config from {resolved_path}...", file=sys.stderr)
+    with resolved_path.open("r", encoding="utf-8") as fh:
+        config_data = yaml.safe_load(fh) or {}
 
-    return AuditConfig(**data)
+    return AuditConfig(**config_data)

--- a/core/config.py
+++ b/core/config.py
@@ -27,7 +27,7 @@ class ListReposConfig(BaseModel):
     resume: bool = (
         True  # whether to use database cache to skip endpoints already collected
     )
-    standard_endpoints: bool = (
+    standard_endpoints_only: bool = (
         True  # whether to limit to standard audit endpoints or collect all available
     )
     sort_by_field: str = "pushed_at"  # field to sort by

--- a/core/config.py
+++ b/core/config.py
@@ -27,6 +27,9 @@ class ListReposConfig(BaseModel):
     resume: bool = (
         True  # whether to use database cache to skip endpoints already collected
     )
+    standard_endpoints: bool = (
+        True  # whether to limit to standard audit endpoints or collect all available
+    )
     sort_by_field: str = "pushed_at"  # field to sort by
     sort_ascending: bool = False  # sort order - descending by default
 

--- a/core/config.py
+++ b/core/config.py
@@ -53,6 +53,20 @@ class AuditConfig(BaseModel):
 
 
 def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
+    """
+    Load an :class:`AuditConfig` from disk.
+
+    Behaviour:
+
+    * If ``config_path`` is ``None``, the function looks for the default
+      file at ``config/audit_config.yaml``. If that file is missing, a
+      fully-defaulted :class:`AuditConfig` is returned (all stages on).
+    * If ``config_path`` is provided but the file does not exist, a
+      :class:`FileNotFoundError` is raised — the caller asked for a
+      specific file and we should not silently fall back.
+    * Missing fields in the YAML fall back to model defaults, so a
+      partial config only needs to list the toggles being changed.
+    """
     if config_path is not None:
         # Explicit override via CLI - must exist if provided
         if not config_path.exists():

--- a/core/config.py
+++ b/core/config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+import sys
 import yaml
 from pydantic import BaseModel, Field
 
@@ -51,14 +52,22 @@ def load_audit_config(config_path: Optional[Path] = None) -> AuditConfig:
       partial config only needs to list the toggles being changed.
     """
     if config_path is None:
+        print(
+            f"No config file specified, looking for default at {DEFAULT_CONFIG_PATH}...",
+            file=sys.stderr,
+        )
         resolved = DEFAULT_CONFIG_PATH
         if not resolved.exists():
+            print(f"Default config file not found: {resolved}", file=sys.stderr)
             return AuditConfig()
     else:
+        print(f"Loading config from {config_path}...", file=sys.stderr)
         resolved = Path(config_path)
         if not resolved.exists():
+            print(f"Config file not found: {resolved}", file=sys.stderr)
             raise FileNotFoundError(f"Config file not found: {resolved}")
 
+    print(f"Reading config from {resolved}...", file=sys.stderr)
     with resolved.open("r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
 

--- a/scripts/github_workflow.py
+++ b/scripts/github_workflow.py
@@ -5,7 +5,7 @@ Refactored to use core modules:
     - Repo discovery / loading      core.github_api.list_org_repos, core.repo_list
     - HTTP transport                core.github_client.GitHubHttpClient
     - Workflow + repo data          RepoCollector with typed repo-scoped endpoints
-    - Stage toggles                 core.config.load_audit_config
+    - Stage workflow_config                 core.config.load_audit_config
 
 Not yet in core (local implementations retained):
     - Workflow YAML uses: parsing
@@ -897,7 +897,7 @@ def _skip(stage_label: str, toggle_name: str) -> None:
 def main() -> None:
     args = _parse_args()
     config: AuditConfig = load_audit_config(args.config_file)
-    toggles = config.workflow_audit
+    workflow_config = config.workflow_audit
 
     client = GitHubHttpClient(auth_method=args.auth)
     storage = SqliteRepoStorage(args.db)
@@ -906,13 +906,13 @@ def main() -> None:
     repo_list = resolve_repo_list(args, client, config)
 
     # Stage 2 - collect_baseline
-    if toggles.collect_baseline_data:
+    if workflow_config.collect_baseline_data:
         collect_baseline(args, client, repo_list, storage)
     else:
         _skip("Stage 2", "collect_baseline_data")
 
     # Stage 3 - collect_additional
-    if toggles.collect_additional_data:
+    if workflow_config.collect_additional_data:
         collect_additional(args, client, repo_list, storage)
     else:
         _skip("Stage 3", "collect_additional_data")
@@ -922,31 +922,31 @@ def main() -> None:
     repo_rows, detail_rows = build_rows(repo_list, storage)
 
     # Stage 5 - write_posture_reports
-    if toggles.gen_posture_reports:
+    if workflow_config.gen_posture_reports:
         write_posture_reports(args, repo_rows, detail_rows)
     else:
         _skip("Stage 5", "gen_posture_reports")
 
     # Stage 6 - actions_analysis
-    if toggles.actions_analysis:
+    if workflow_config.actions_analysis:
         actions_analysis(client, detail_rows)
     else:
         _skip("Stage 6", "actions_analysis")
 
     # Stage 7 - permissions_analysis
-    if toggles.permissions_analysis:
+    if workflow_config.permissions_analysis:
         permissions_analysis(client, detail_rows)
     else:
         _skip("Stage 7", "permissions_analysis")
 
     # Stage 8 - credentials_analysis
-    if toggles.credentials_analysis:
+    if workflow_config.credentials_analysis:
         credentials_analysis(client, detail_rows)
     else:
         _skip("Stage 8", "credentials_analysis")
 
     # Stage 9 - trigger_risk_analysis
-    if toggles.trigger_risk_analysis:
+    if workflow_config.trigger_risk_analysis:
         trigger_risk_analysis(client, detail_rows)
     else:
         _skip("Stage 9", "trigger_risk_analysis")

--- a/scripts/github_workflow.py
+++ b/scripts/github_workflow.py
@@ -5,7 +5,7 @@ Refactored to use core modules:
     - Repo discovery / loading      core.github_api.list_org_repos, core.repo_list
     - HTTP transport                core.github_client.GitHubHttpClient
     - Workflow + repo data          RepoCollector with typed repo-scoped endpoints
-    - Stage workflow_config                 core.config.load_audit_config
+    - Script config                 core.config.load_audit_config
 
 Not yet in core (local implementations retained):
     - Workflow YAML uses: parsing

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -16,7 +16,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pandas as pd
 
-from argparse import BooleanOptionalAction
 from core.collector import RepoCollector
 from core.config import AuditConfig, load_audit_config
 from core.github_api import (
@@ -67,51 +66,6 @@ def _parse_args() -> argparse.Namespace:
         help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     parser.add_argument(
-        "--repo-file",
-        help="Path to repo list file (YAML preferred).",
-    )
-    parser.add_argument(
-        "--db-path",
-        default=None,
-        help=f"SQLite path for core storage (default: {DEFAULT_DB_PATH}).",
-    )
-    parser.add_argument(
-        "--output-filename",
-        help="Output filename for Excel export (default: list_repos.xlsx in output directory).",
-    )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        help="Only process the first N repos from --repo-file.",
-    )
-    parser.add_argument(
-        "--sort-by",
-        help=("Field to sort by.  Default: pushed_at descending."),
-    )
-    parser.add_argument(
-        "--sort-ascending",
-        action=BooleanOptionalAction,
-        default=None,
-        help="Sort order for --sort-by field (default: false [descending]).",
-    )
-    parser.add_argument(
-        "--standard-endpoints",
-        action="store_true",
-        help=(
-            "Use the reduced standard endpoint set (faster). "
-            "By default, all repo endpoints are collected."
-        ),
-    )
-    parser.add_argument(
-        "--resume",
-        action=BooleanOptionalAction,
-        default=None,
-        help=(
-            "Skip endpoints already collected in the database for each repo. "
-            "Safe to use after an interrupted run."
-        ),
-    )
-    parser.add_argument(
         "--auth",
         choices=["pat", "app", "cli"],
         default=None,
@@ -130,25 +84,17 @@ def main() -> None:
     list_repos_config = config.list_repos
 
     # Define Variables from Config and/or Args
-    database_path = args.db_path if args.db_path else list_repos_config.database_path
+    database_path = list_repos_config.database_path
     if database_path is not None and not Path(database_path).is_absolute():
         database_path = str(Path(PROJECT_ROOT) / database_path)
-    output_filename = (
-        args.output_filename
-        if args.output_filename
-        else list_repos_config.output_filename
-    )
-    repo_file = args.repo_file if args.repo_file else config.repo_list_file
+    output_filename = list_repos_config.output_filename
+    repo_file = config.repo_list_file
     if repo_file is not None and not Path(repo_file).is_absolute():
         repo_file = str(Path(PROJECT_ROOT) / repo_file)
-    repo_limit = args.limit if args.limit is not None else list_repos_config.repo_limit
-    resume = args.resume if args.resume is not None else list_repos_config.resume
-    sort_by_field = args.sort_by if args.sort_by else list_repos_config.sort_by_field
-    sort_asc = (
-        args.sort_ascending
-        if args.sort_ascending is not None
-        else list_repos_config.sort_ascending
-    )
+    repo_limit = list_repos_config.repo_limit
+    resume = list_repos_config.resume
+    sort_by_field = list_repos_config.sort_by_field
+    sort_asc = list_repos_config.sort_ascending
 
     # List Repos Config Debug
     print(section_break, file=sys.stderr)
@@ -158,12 +104,17 @@ def main() -> None:
     )
 
     print(section_break, file=sys.stderr)
+
     print(f"Database Path: {database_path}", file=sys.stderr)
     print(f"Using repo file: {repo_file}", file=sys.stderr)
     print(f"Repo limit: {repo_limit}", file=sys.stderr)
     print(f"Resume: {resume}", file=sys.stderr)
     print(f"Sort by field: {sort_by_field}", file=sys.stderr)
     print(f"Sort ascending: {sort_asc}", file=sys.stderr)
+    print(
+        f"Standard endpoints only: {list_repos_config.standard_endpoints}",
+        file=sys.stderr,
+    )
 
     print(sub_section_break, file=sys.stderr)
 
@@ -188,7 +139,9 @@ def main() -> None:
 
     storage = SqliteRepoStorage(database_path)
     selected_endpoints = (
-        STANDARD_REPO_AUDIT_ENDPOINTS if args.standard_endpoints else REPO_ENDPOINTS
+        STANDARD_REPO_AUDIT_ENDPOINTS
+        if list_repos_config.standard_endpoints
+        else REPO_ENDPOINTS
     )
     collector = RepoCollector(
         storage=storage, endpoints=selected_endpoints, auth_method=args.auth

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import argparse
 import atexit
-import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 # add project root to path for core imports
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
 
 from core.collector import RepoCollector
+from core.config import AuditConfig, load_audit_config
 from core.github_api import (
     REPO_ENDPOINTS,
     STANDARD_REPO_AUDIT_ENDPOINTS,
@@ -26,14 +27,20 @@ from core.repo_list import load_repo_list_file
 from core.storage import SqliteRepoStorage
 from core.utils import base_directory_setup
 
+section_break = "\n" + ("=" * 80) + "\n"
+sub_section_break = "\n" + ("-" * 80) + "\n"
+
 # TODO: PROJECT_ROOT will be removed as an output of base_directory_setup once all scripts updated to use audit_config.yaml for repo_list loading
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 
 OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, "list_repos")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+# Set Default Config File Path
+DEFAULT_CONFIG_PATH = os.path.join(PROJECT_ROOT, "config", "audit_config.yaml")
 # Set Default Database Path
 DEFAULT_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "repo_audit.db")
+
 
 __start_time: float | None = None
 
@@ -57,17 +64,16 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--repo-file",
-        required=True,
         help="Path to repo list file (YAML preferred).",
     )
     parser.add_argument(
-        "--db",
+        "--db-path",
         default=DEFAULT_DB_PATH,
         help=f"SQLite path for core storage (default: {DEFAULT_DB_PATH}).",
     )
     parser.add_argument(
-        "--excel",
-        help="Write an Excel workbook with Repos and Summary sheets.",
+        "--output-filename",
+        help="Output filename for Excel export (default: list_repos.xlsx in output directory).",
     )
     parser.add_argument(
         "--limit",
@@ -75,11 +81,13 @@ def _parse_args() -> argparse.Namespace:
         help="Only process the first N repos from --repo-file.",
     )
     parser.add_argument(
-        "--sort",
-        help=(
-            "Sort field for output rows. Prefix with '-' for descending "
-            "or '+' for ascending. Default: pushed_at descending."
-        ),
+        "--sort-by",
+        help=("Field to sort by.  Default: pushed_at descending."),
+    )
+    parser.add_argument(
+        "--sort-ascending",
+        type=bool,
+        help="Sort order for --sort-by field (default: false [descending]).",
     )
     parser.add_argument(
         "--standard-endpoints",
@@ -103,17 +111,18 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="Select GitHub authentication method explicitly",
     )
+    parser.add_argument(
+        "--config-file",
+        default=DEFAULT_CONFIG_PATH,
+        type=Path,
+        help=(
+            "Path to audit config YAML file. If not provided, the script will "
+            "look for the default config at config/audit_config.yaml. If the "
+            "default config file is missing, a fully-defaulted config will be "
+            "used (all stages on)."
+        ),
+    )
     return parser.parse_args()
-
-
-def _derive_sort(raw_sort: str | None) -> tuple[str, bool]:
-    if not raw_sort:
-        return "pushed_at", False
-    if raw_sort.startswith("-"):
-        return raw_sort[1:], False
-    if raw_sort.startswith("+"):
-        return raw_sort[1:], True
-    return raw_sort, True
 
 
 def main() -> None:
@@ -121,24 +130,64 @@ def main() -> None:
     __start_time = time.monotonic()
 
     args = _parse_args()
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    list_repos_config = config.list_repos
+
+    # Define Variables from Config and/or Args
+    database_path = args.db_path if args.db_path else list_repos_config.database_path
+    output_filename = (
+        args.output_filename
+        if args.output_filename
+        else list_repos_config.output_filename
+    )
+    repo_file = args.repo_file if args.repo_file else config.repo_list_file
+    repo_limit = args.limit if args.limit is not None else list_repos_config.repo_limit
+    resume = args.resume if args.resume else list_repos_config.resume
+    sort_by_field = args.sort_by if args.sort_by else list_repos_config.sort_by_field
+    sort_asc = (
+        args.sort_ascending
+        if args.sort_ascending is not None
+        else list_repos_config.sort_ascending
+    )
+
+    # List Repos Config Debug
+    print(section_break, file=sys.stderr)
+
+    print(
+        "list_repos to be executed with the following config values:", file=sys.stderr
+    )
+
+    print(section_break, file=sys.stderr)
+    print(f"Database Path: {database_path}", file=sys.stderr)
+    print(f"Using repo file: {repo_file}", file=sys.stderr)
+    print(f"Repo limit: {repo_limit}", file=sys.stderr)
+    print(f"Resume: {resume}", file=sys.stderr)
+    print(f"Sort by field: {sort_by_field}", file=sys.stderr)
+    print(f"Sort ascending: {sort_asc}", file=sys.stderr)
+
+    print(sub_section_break, file=sys.stderr)
 
     try:
-        repo_list = load_repo_list_file(args.repo_file)
+        repo_list = load_repo_list_file(repo_file)
     except Exception as exc:
         print(f"Failed to read repo file: {exc}", file=sys.stderr)
         sys.exit(2)
 
-    if args.limit is not None:
-        if args.limit < 0:
+    if repo_limit is not None:
+        if repo_limit < 0:
             print("--limit must be >= 0", file=sys.stderr)
             sys.exit(2)
-        repo_list = repo_list[: args.limit]
+        repo_list = repo_list[:repo_limit]
 
     if not repo_list:
-        print("No repositories found in repo file after applying --limit.")
+        print(
+            "No repositories found in repo file after applying --limit.",
+            file=sys.stderr,
+        )
         return
 
-    storage = SqliteRepoStorage(args.db)
+    storage = SqliteRepoStorage(database_path)
     selected_endpoints = (
         STANDARD_REPO_AUDIT_ENDPOINTS if args.standard_endpoints else REPO_ENDPOINTS
     )
@@ -147,7 +196,7 @@ def main() -> None:
     )
 
     primary_org = repo_list[0].split("/", 1)[0]
-    collector.collect(primary_org, repos=repo_list, resume=args.resume)
+    collector.collect(primary_org, repos=repo_list, resume=resume)
 
     rows: list[dict[str, Any]] = []
     for full_name in repo_list:
@@ -156,31 +205,26 @@ def main() -> None:
             rows.append(repo_data_to_list_row(full_name, data))
 
     df = pd.DataFrame(rows)
-    sort_key, sort_asc = _derive_sort(args.sort)
-    if not df.empty and sort_key in df.columns:
-        df = df.sort_values(by=sort_key, ascending=sort_asc, na_position="last")
-    elif sort_key:
-        print(f"Warning: sort key '{sort_key}' not a column", file=sys.stderr)
+    if not df.empty and sort_by_field in df.columns:
+        df = df.sort_values(by=sort_by_field, ascending=sort_asc, na_position="last")
+    elif sort_by_field:
+        print(f"Warning: sort key '{sort_by_field}' not a column", file=sys.stderr)
 
     summary = build_repo_summary_table(df)
 
-    if args.excel:
-        excel_path = os.path.join(OUTPUT_DIR, args.excel)
-        try:
-            with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
-                df.to_excel(writer, index=False, sheet_name="Repos")
-                summary.to_excel(writer, index=False, sheet_name="Summary")
-            print(f"Wrote {excel_path}", file=sys.stderr)
-        except ImportError:
-            print(
-                "Excel export requires the openpyxl package. "
-                "Install it with `pip install openpyxl` and retry.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-    if not args.excel:
-        print(json.dumps(df.to_dict(orient="records"), indent=2))
+    excel_path = os.path.join(OUTPUT_DIR, args.output_filename)
+    try:
+        with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
+            df.to_excel(writer, index=False, sheet_name="Repos")
+            summary.to_excel(writer, index=False, sheet_name="Summary")
+        print(f"Wrote {excel_path}", file=sys.stderr)
+    except ImportError:
+        print(
+            "Excel export requires the openpyxl package. "
+            "Install it with `pip install openpyxl` and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -112,7 +112,7 @@ def main() -> None:
     print(f"Sort by field: {sort_by_field}", file=sys.stderr)
     print(f"Sort ascending: {sort_asc}", file=sys.stderr)
     print(
-        f"Standard endpoints only: {list_repos_config.standard_endpoints}",
+        f"Standard endpoints only: {list_repos_config.standard_endpoints_only}",
         file=sys.stderr,
     )
 
@@ -140,7 +140,7 @@ def main() -> None:
     storage = SqliteRepoStorage(database_path)
     selected_endpoints = (
         STANDARD_REPO_AUDIT_ENDPOINTS
-        if list_repos_config.standard_endpoints
+        if list_repos_config.standard_endpoints_only
         else REPO_ENDPOINTS
     )
     collector = RepoCollector(

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pandas as pd
 
+from argparse import BooleanOptionalAction
 from core.collector import RepoCollector
 from core.config import AuditConfig, load_audit_config
 from core.github_api import (
@@ -36,11 +37,8 @@ BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, "list_repos")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-# Set Default Config File Path
-DEFAULT_CONFIG_PATH = os.path.join(PROJECT_ROOT, "config", "audit_config.yaml")
 # Set Default Database Path
 DEFAULT_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "repo_audit.db")
-
 
 __start_time: float | None = None
 
@@ -68,7 +66,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--db-path",
-        default=DEFAULT_DB_PATH,
+        default=None,
         help=f"SQLite path for core storage (default: {DEFAULT_DB_PATH}).",
     )
     parser.add_argument(
@@ -86,7 +84,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--sort-ascending",
-        type=bool,
+        type=BooleanOptionalAction,
+        default=None,
         help="Sort order for --sort-by field (default: false [descending]).",
     )
     parser.add_argument(
@@ -99,7 +98,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--resume",
-        action="store_true",
+        type=BooleanOptionalAction,
+        default=None,
         help=(
             "Skip endpoints already collected in the database for each repo. "
             "Safe to use after an interrupted run."
@@ -113,14 +113,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--config-file",
-        default=DEFAULT_CONFIG_PATH,
+        default=None,
         type=Path,
-        help=(
-            "Path to audit config YAML file. If not provided, the script will "
-            "look for the default config at config/audit_config.yaml. If the "
-            "default config file is missing, a fully-defaulted config will be "
-            "used (all stages on)."
-        ),
+        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     return parser.parse_args()
 
@@ -136,14 +131,18 @@ def main() -> None:
 
     # Define Variables from Config and/or Args
     database_path = args.db_path if args.db_path else list_repos_config.database_path
+    if database_path is not None and not Path(database_path).is_absolute():
+        database_path = str(Path(PROJECT_ROOT) / database_path)
     output_filename = (
         args.output_filename
         if args.output_filename
         else list_repos_config.output_filename
     )
     repo_file = args.repo_file if args.repo_file else config.repo_list_file
+    if repo_file is not None and not Path(repo_file).is_absolute():
+        repo_file = str(Path(PROJECT_ROOT) / repo_file)
     repo_limit = args.limit if args.limit is not None else list_repos_config.repo_limit
-    resume = args.resume if args.resume else list_repos_config.resume
+    resume = args.resume if args.resume is not None else list_repos_config.resume
     sort_by_field = args.sort_by if args.sort_by else list_repos_config.sort_by_field
     sort_asc = (
         args.sort_ascending
@@ -212,7 +211,7 @@ def main() -> None:
 
     summary = build_repo_summary_table(df)
 
-    excel_path = os.path.join(OUTPUT_DIR, args.output_filename)
+    excel_path = os.path.join(OUTPUT_DIR, output_filename)
     try:
         with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
             df.to_excel(writer, index=False, sheet_name="Repos")

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -61,6 +61,12 @@ def _parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument(
+        "--config-file",
+        default=None,
+        type=Path,
+        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
+    )
+    parser.add_argument(
         "--repo-file",
         help="Path to repo list file (YAML preferred).",
     )
@@ -110,12 +116,6 @@ def _parse_args() -> argparse.Namespace:
         choices=["pat", "app", "cli"],
         default=None,
         help="Select GitHub authentication method explicitly",
-    )
-    parser.add_argument(
-        "--config-file",
-        default=None,
-        type=Path,
-        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     return parser.parse_args()
 

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -84,7 +84,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--sort-ascending",
-        type=BooleanOptionalAction,
+        action=BooleanOptionalAction,
         default=None,
         help="Sort order for --sort-by field (default: false [descending]).",
     )
@@ -98,7 +98,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--resume",
-        type=BooleanOptionalAction,
+        action=BooleanOptionalAction,
         default=None,
         help=(
             "Skip endpoints already collected in the database for each repo. "

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -181,7 +181,7 @@ def main() -> None:
 
     if not repo_list:
         print(
-            "No repositories found in repo file after applying --limit.",
+            "No repositories found in repo file (after applying any limit).",
             file=sys.stderr,
         )
         return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Unit tests for core.config."""
 
+import pytest
 import yaml
 
 from core.config import (
@@ -27,10 +28,17 @@ def test_load_returns_defaults_when_default_path_missing(tmp_path, monkeypatch):
     assert config == AuditConfig()
 
 
-# def test_load_raises_when_explicit_path_missing(tmp_path):
-#     missing = tmp_path / "does_not_exist.yaml"
-#     with pytest.raises(FileNotFoundError):
-#         load_audit_config(missing)
+def test_load_raises_when_explicit_path_missing(tmp_path):
+    missing = tmp_path / "does_not_exist.yaml"
+    with pytest.raises(FileNotFoundError):
+        load_audit_config(missing)
+
+
+def test_load_returns_config_from_file(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text("repo_list_file: custom_repos.yaml")
+    config = load_audit_config(config_file)
+    assert config.repo_list_file == "custom_repos.yaml"
 
 
 def test_load_respects_stage_toggles(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,9 +21,16 @@ def test_defaults_all_stages_enabled():
     assert config.repo_list_file == "repo_list.yaml"
 
 
-def test_load_returns_defaults_when_default_path_missing(tmp_path):
-    config = load_audit_config(tmp_path / "nonexistent_config.yaml")
+def test_load_returns_defaults_when_default_path_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = load_audit_config()
     assert config == AuditConfig()
+
+
+# def test_load_raises_when_explicit_path_missing(tmp_path):
+#     missing = tmp_path / "does_not_exist.yaml"
+#     with pytest.raises(FileNotFoundError):
+#         load_audit_config(missing)
 
 
 def test_load_respects_stage_toggles(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 """Unit tests for core.config."""
 
-import pytest
 import yaml
 
 from core.config import (
@@ -22,16 +21,9 @@ def test_defaults_all_stages_enabled():
     assert config.repo_list_file == "repo_list.yaml"
 
 
-def test_load_returns_defaults_when_default_path_missing(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    config = load_audit_config()
+def test_load_returns_defaults_when_default_path_missing(tmp_path):
+    config = load_audit_config(tmp_path / "nonexistent_config.yaml")
     assert config == AuditConfig()
-
-
-def test_load_raises_when_explicit_path_missing(tmp_path):
-    missing = tmp_path / "does_not_exist.yaml"
-    with pytest.raises(FileNotFoundError):
-        load_audit_config(missing)
 
 
 def test_load_respects_stage_toggles(tmp_path):


### PR DESCRIPTION
# Introduction :pencil2:

Solves #131 by adding YAML configuration support for `scripts/list_repos.py` via the central `config/audit_config.yaml`, aligning it with the existing config-loading pattern planned for the rest of the scripts.

## Resolution :heavy_check_mark:

- Extends `core/config.py`:
  - Extends `core.config.AuditConfig` with a `list_repos` section (with corresponding `ListReposConfig` Pydantic model)
  - `config/audit_config.yaml` updated with attributes corresponding to CLI arguments.
- `scripts/list_repos.py` updated to read the repo file, database path, repo limit, resume behaviour, and sort settings from YAML, with CLI overrides still supported.

## Miscellaneous :heavy_plus_sign:

- Minor naming cleanup in `scripts/github_workflow.py`
- Expanded config loading test coverage.
