### PR TITLE
Extend YAML Config Support: org_security_posture.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,20 +207,8 @@ uv run python scripts/org_security_posture.py <org> [--excel path] [--repo-file 
 **Examples:**
 
 ```bash
-# Export a workbook for review
-uv run python scripts/org_security_posture.py ministryofjustice --excel moj-security-posture.xlsx
-
 # Export a workbook for review, authenticating via PAT specifically
 uv run python scripts/org_security_posture.py ministryofjustice --excel moj-security-posture.xlsx --auth pat
-
-# Limit supply-chain checks to repos from repo_list.yaml
-uv run python scripts/org_security_posture.py ministryofjustice --repo-file
-
-# Limit supply-chain checks to repos from a custom list file
-uv run python scripts/org_security_posture.py ministryofjustice --repo-file custom_repos.yaml --excel moj-security-posture.xlsx
-
-# Force a fresh pull instead of using the local cache
-uv run python scripts/org_security_posture.py ministryofjustice --no-cache
 ```
 
 ### 4. `dashboard.py` - Interactive Web Dashboard

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ uv run python scripts/org_security_posture.py --config-file /path/to/config.yaml
 
 ```bash
 # Export a workbook for review (org + output file come from config), authenticating via PAT specifically
- uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml --auth pat
+uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml --auth pat
 ```
 
 ### 4. `dashboard.py` - Interactive Web Dashboard
@@ -473,7 +473,7 @@ uv run python scripts/archive_repos.py ministryofjustice --audit-db /tmp/archive
 uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml
 
 # 2. Set `use_cache: false` in config/audit_config.yaml to run without cache when you need fresh data
-uv run python scripts/org_security_posture.py ministryofjustice --no-cache
+uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml
 
 # 3. Limit supply-chain checks to repos listed in repo_list.yaml - adjust repo_list_file for alternate lists
 uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml

--- a/README.md
+++ b/README.md
@@ -470,13 +470,13 @@ uv run python scripts/archive_repos.py ministryofjustice --audit-db /tmp/archive
 
 ```bash
 # 1. Generate an organisation-wide posture workbook
-uv run python scripts/org_security_posture.py ministryofjustice --excel moj-security-posture.xlsx
+uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml
 
-# 2. Re-run without cache when you need fresh data
+# 2. Set `use_cache: false` in config/audit_config.yaml to run without cache when you need fresh data
 uv run python scripts/org_security_posture.py ministryofjustice --no-cache
 
-# 3. Limit supply-chain checks to repos listed in repo_list.yaml
-uv run python scripts/org_security_posture.py ministryofjustice --repo-file --excel moj-security-posture.xlsx
+# 3. Limit supply-chain checks to repos listed in repo_list.yaml - adjust repo_list_file for alternate lists
+uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml
 ```
 
 ### Batch Audit Using File
@@ -576,8 +576,7 @@ uv run python scripts/archive_repos.py ministryofjustice --cache-only --sort -da
 ### Export organisation posture report
 
 ```bash
-uv run python scripts/org_security_posture.py ministryofjustice --excel moj-security-posture.xlsx
-uv run python scripts/org_security_posture.py ministryofjustice --repo-file
+uv run python scripts/org_security_posture.py
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ uv run python scripts/list_repos.py --config-file config/audit_config.yaml --aut
 **Config Parameters:**
 
 - `database_path: <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
-- `output-filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
+- `output_filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
 - `repo_limit: <N>` - Crop the loaded `repo_list_file` list to the first N entries before collection - ideal for adhoc quick checks.
 - `use_cache: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 - `standard_endpoints_only: true/false` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
@@ -199,20 +199,20 @@ uv run python scripts/org_security_posture.py --config-file /path/to/config.yaml
 **Config Parameters:**
 
 - `database_path: <path>` - SQLite path for core storage (default: `internal/org_security_posture.db`).
-- `output-filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
+- `output_filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
 - `use_cache: true/false` - Skip endpoints already persisted in the database for supply-chain analysis
 
 **Output:**
 
 - A summary printed to stderr
 - Excel workbook output to `output/org_security_posture/`
-- Cached results stored in `internal/org_posture_cache.db` for reuse on later runs
+- Cached results stored in `internal/org_security_posture.db` for reuse on later runs
 
 **Examples:**
 
 ```bash
-# Export a workbook for review, authenticating via PAT specifically
-uv run python scripts/org_security_posture.py ministryofjustice --excel moj-security-posture.xlsx --auth pat
+# Export a workbook for review (org + output file come from config), authenticating via PAT specifically
+ uv run python scripts/org_security_posture.py --config-file config/audit_config.yaml --auth pat
 ```
 
 ### 4. `dashboard.py` - Interactive Web Dashboard

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ the core SQLite storage, and optionally exports an Excel workbook.
 **Usage:**
 
 ```bash
-uv run python scripts/list_repos.py --repo-file <file> [options]
+uv run python scripts/list_repos.py --config-file config/audit_config.yaml --auth pat
 ```
 
 **CLI Options:**
@@ -94,7 +94,7 @@ uv run python scripts/list_repos.py --repo-file <file> [options]
 - `database_path: <path>` - SQLite path for core storage (default: `internal/repo_audit.db`).
 - `output-filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
 - `repo_limit: <N>` - Crop the loaded `repo_list_file` list to the first N entries before collection - ideal for adhoc quick checks.
-- `resume: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
+- `use_cache: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 - `standard_endpoints_only: true/false` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
 - `sort_by_field: <column>` - Sort by repo field. Defaults to last updated (`pushed_at`).
 - `sort_ascending: <true/false>` - Sort order for `sort_by` field, defaults to `false` / descending
@@ -188,21 +188,25 @@ Performs an organisation-level audit that complements the per-repo scripts. It c
 **Usage:**
 
 ```bash
-uv run python scripts/org_security_posture.py <org> [--excel path] [--repo-file [path]] [--no-cache]
+uv run python scripts/org_security_posture.py --config-file /path/to/config.yaml --auth pat/app/cli
 ```
 
-**Options:**
+**CLI Options:**
 
-- `--excel <path>` - Write the report to a multi-sheet Excel workbook.
-- `--repo-file [path]` - Limit repo-level supply-chain checks to repos in a list file. If passed without a value, defaults to `repo_list.yaml`.
-- `--no-cache` - Ignore the saved posture cache and fetch fresh data.
+- `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
 - `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.
+
+**Config Parameters:**
+
+- `database_path: <path>` - SQLite path for core storage (default: `internal/org_security_posture.db`).
+- `output-filename: <filename>.xlsx` - Export results to Excel file `<filename>.xlsx`. Requires `openpyxl`.
+- `use_cache: true/false` - Skip endpoints already persisted in the database for supply-chain analysis
 
 **Output:**
 
 - A summary printed to stderr
-- Excel workbook output when `--excel` is supplied
-- Cached results stored in `internal/rg_posture_cache.db` for reuse on later runs
+- Excel workbook output to `output/org_security_posture/`
+- Cached results stored in `internal/org_posture_cache.db` for reuse on later runs
 
 **Examples:**
 

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -19,7 +19,7 @@ list_repos:
 org_security_posture:
   database_path: "internal/org_security_posture.db"
   output_filename: "org_security_posture.xlsx"
-  # resume: true
+  resume: true
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -10,16 +10,16 @@ list_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "list_repos.xlsx"
   repo_limit: 50
-  resume: true
   standard_endpoints_only: true
   sort_by_field: "pushed_at"
   sort_ascending: false
+  use_cache: true
 
 # Script config for org_security_posture.py.
 org_security_posture:
   database_path: "internal/org_security_posture.db"
   output_filename: "org_security_posture.xlsx"
-  resume: true
+  use_cache: true
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -15,6 +15,11 @@ list_repos:
   sort_by_field: "pushed_at"
   sort_ascending: false
 
+# Script config for org_security_posture.py.
+org_security_posture:
+  database_path: "internal/org_security_posture.db"
+  output_filename: "org_security_posture.xlsx"
+  resume: true
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -19,7 +19,7 @@ list_repos:
 org_security_posture:
   database_path: "internal/org_security_posture.db"
   output_filename: "org_security_posture.xlsx"
-  resume: true
+  # resume: true
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/core/config.py
+++ b/core/config.py
@@ -44,7 +44,7 @@ class OrgSecurityPostureConfig(BaseModel):
         "org_security_posture.xlsx"  # output file for org posture summary data
     )
     resume: bool = (
-        True  # whether to use database cache to skip endpoints already collected
+        True  # whether to reuse cached posture data from the org posture database
     )
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -24,7 +24,7 @@ class ListReposConfig(BaseModel):
     )
     output_filename: str = "list_repos.xlsx"  # output file for repo summary data
     repo_limit: Optional[int] = 400
-    resume: bool = (
+    use_cache: bool = (
         True  # whether to use database cache to skip endpoints already collected
     )
     standard_endpoints_only: bool = (
@@ -43,7 +43,7 @@ class OrgSecurityPostureConfig(BaseModel):
     output_filename: str = (
         "org_security_posture.xlsx"  # output file for org posture summary data
     )
-    resume: bool = (
+    use_cache: bool = (
         True  # whether to reuse cached posture data from the org posture database
     )
 

--- a/core/config.py
+++ b/core/config.py
@@ -43,9 +43,9 @@ class OrgSecurityPostureConfig(BaseModel):
     output_filename: str = (
         "org_security_posture.xlsx"  # output file for org posture summary data
     )
-    resume: bool = (
-        True  # whether to use database cache to skip endpoints already collected
-    )
+    # resume: bool = (
+    #     True  # whether to use database cache to skip endpoints already collected
+    # )
 
 
 class WorkflowAuditConfig(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -43,9 +43,9 @@ class OrgSecurityPostureConfig(BaseModel):
     output_filename: str = (
         "org_security_posture.xlsx"  # output file for org posture summary data
     )
-    # resume: bool = (
-    #     True  # whether to use database cache to skip endpoints already collected
-    # )
+    resume: bool = (
+        True  # whether to use database cache to skip endpoints already collected
+    )
 
 
 class WorkflowAuditConfig(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -34,6 +34,20 @@ class ListReposConfig(BaseModel):
     sort_ascending: bool = False  # sort order - descending by default
 
 
+class OrgSecurityPostureConfig(BaseModel):
+    """Config for ``org_security_posture.py`` script."""
+
+    database_path: str = (
+        "internal/org_security_posture.db"  # SQLite cache file for org posture data
+    )
+    output_filename: str = (
+        "org_security_posture.xlsx"  # output file for org posture summary data
+    )
+    resume: bool = (
+        True  # whether to use database cache to skip endpoints already collected
+    )
+
+
 class WorkflowAuditConfig(BaseModel):
     """Per-stage toggles for ``github_workflow.py``."""
 
@@ -52,6 +66,9 @@ class AuditConfig(BaseModel):
     github_organization: str = "ministryofjustice"
     repo_list_file: str = "repo_list.yaml"
     list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
+    org_security_posture: OrgSecurityPostureConfig = Field(
+        default_factory=OrgSecurityPostureConfig
+    )
     workflow_audit: WorkflowAuditConfig = Field(default_factory=WorkflowAuditConfig)
 
 

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -29,7 +29,6 @@ from core.models import LargeBlobData, RepoData, RepoTreeProcessedData
 
 # Size limits in bytes (50/100 MB converted to bytes for ease of processing)
 SOFT_LIMIT = 50 * 1024 * 1024
-SOFT_LIMIT = 50 * 1024 * 1024
 HARD_LIMIT = 100 * 1024 * 1024
 
 

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -148,7 +148,7 @@ def main() -> None:
     )
 
     primary_org = repo_list[0].split("/", 1)[0]
-    collector.collect(primary_org, repos=repo_list, use_cache=use_cache)
+    collector.collect(primary_org, repos=repo_list, resume=use_cache)
 
     rows: list[dict[str, Any]] = []
     for full_name in repo_list:

--- a/scripts/list_repos.py
+++ b/scripts/list_repos.py
@@ -92,7 +92,7 @@ def main() -> None:
     if repo_file is not None and not Path(repo_file).is_absolute():
         repo_file = str(Path(PROJECT_ROOT) / repo_file)
     repo_limit = list_repos_config.repo_limit
-    resume = list_repos_config.resume
+    use_cache = list_repos_config.use_cache
     sort_by_field = list_repos_config.sort_by_field
     sort_asc = list_repos_config.sort_ascending
 
@@ -108,7 +108,7 @@ def main() -> None:
     print(f"Database Path: {database_path}", file=sys.stderr)
     print(f"Using repo file: {repo_file}", file=sys.stderr)
     print(f"Repo limit: {repo_limit}", file=sys.stderr)
-    print(f"Resume: {resume}", file=sys.stderr)
+    print(f"use_cache: {use_cache}", file=sys.stderr)
     print(f"Sort by field: {sort_by_field}", file=sys.stderr)
     print(f"Sort ascending: {sort_asc}", file=sys.stderr)
     print(
@@ -148,7 +148,7 @@ def main() -> None:
     )
 
     primary_org = repo_list[0].split("/", 1)[0]
-    collector.collect(primary_org, repos=repo_list, resume=resume)
+    collector.collect(primary_org, repos=repo_list, use_cache=use_cache)
 
     rows: list[dict[str, Any]] = []
     for full_name in repo_list:

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -8,7 +8,6 @@ import atexit
 import os
 import sys
 import time
-from pathlib import Path
 from typing import Any, Literal
 
 # add project root to path for core imports
@@ -18,7 +17,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
 
 from core.collector import OrgEndpointCollector
-from core.config import load_audit_config, AuditConfig
 from core.github_api import (
     OrgActionsEndpoint,
     OrgAuditLogEndpoint,
@@ -38,9 +36,6 @@ from core.repo_list import load_repo_list_file
 from core.storage import SqliteOrgStorage
 from core.utils import base_directory_setup
 
-section_break = "\n" + ("=" * 80) + "\n"
-sub_section_break = "\n" + ("-" * 80) + "\n"
-
 # TODO:
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 
@@ -51,11 +46,15 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 # Set Default Cache and Repo List Paths
 ORG_CACHE_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "org_posture_cache.db")
 
+# TODO: Remove hardcoded YAML_FILE once repo list loading updated to use audit_config.yaml for default with CLI override
+DEFAULT_REPO_FILE = os.path.join(PROJECT_ROOT, "repo_list.yaml")
+
 __start_time: float | None = None
 
 
 # TODO: Consider moving to core.utils as repeated across scripts or to main.py when shared entrypoint developed
 def _report_elapsed() -> None:
+    """Report elapsed time on script exit."""
     if __start_time is not None:
         elapsed = time.monotonic() - __start_time
         print(f"Elapsed time: {elapsed:.2f}s", file=sys.stderr)
@@ -65,14 +64,25 @@ atexit.register(_report_elapsed)
 
 
 def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Audit organisation security posture using core collectors."
     )
+    parser.add_argument("org", help="GitHub organisation login.")
+    parser.add_argument("--excel", help="Write Excel workbook output.")
     parser.add_argument(
-        "--config-file",
-        default=None,
-        type=Path,
-        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
+        "--repo-file",
+        nargs="?",
+        const=DEFAULT_REPO_FILE,
+        help=(
+            "Limit supply-chain checks to repos in a file. "
+            "Pass a path, or use --repo-file without a value to default to repo_list.yaml."
+        ),
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Ignore on-disk posture cache and fetch fresh data.",
     )
     parser.add_argument(
         "--auth",
@@ -84,6 +94,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _load_cache(org: str, storage: SqliteOrgStorage) -> dict[str, Any]:
+    """Load cached posture data for an org, if available and not expired."""
     try:
         cached = storage.read_cache(org)
         if cached is None:
@@ -101,6 +112,7 @@ def _load_cache(org: str, storage: SqliteOrgStorage) -> dict[str, Any]:
 
 
 def _save_cache(org: str, cache: dict[str, Any], storage: SqliteOrgStorage) -> None:
+    """Save posture data to cache with current timestamp."""
     updated_at = time.time()
     storage.upsert_cache(org, cache, updated_at)
     print(f"  Saved cache: {ORG_CACHE_DB_PATH}", file=sys.stderr)
@@ -112,13 +124,10 @@ def run_full_audit(
     repo_full_names: list[str] | None = None,
     use_cache: bool = True,
 ) -> dict[str, Any]:
+    """Run a full audit for the given organization."""
     cache_storage = SqliteOrgStorage(ORG_CACHE_DB_PATH)
     cache_storage.init()
-    cache = (
-        _load_cache(org, cache_storage)
-        if use_cache
-        else {print("  use_cache is False, fetching fresh data...", file=sys.stderr)}
-    )
+    cache = _load_cache(org, cache_storage) if use_cache else {}
     client = GitHubHttpClient(auth_method)
 
     report: dict[str, Any] = {
@@ -126,6 +135,7 @@ def run_full_audit(
         "audited_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
 
+    print(f"\nCollecting data for org: {org}", file=sys.stderr)
     collector = OrgEndpointCollector(
         client=client,
         endpoints=[
@@ -147,6 +157,7 @@ def run_full_audit(
 
     report["org_overview"] = org_data["org_overview"].data
 
+    print("\n Collecting High-Level Org Settings...", file=sys.stderr)
     report["1_org_settings"] = {
         "total_members": {
             "access": "ok",
@@ -171,10 +182,14 @@ def run_full_audit(
         },
     }
 
+    print("\n Collecting GHAS Alert Data...", file=sys.stderr)
+
     report["2_ghas_alerts"] = {
         "code_scanning": org_data["org_code_scanning_alerts"].model_dump(),
         "secret_scanning": org_data["org_secret_scanning_alerts"].model_dump(),
     }
+
+    print("\n Collecting Dependency Supply Chain Data...", file=sys.stderr)
 
     section3_col_name = "3_dependency_supply_chain"
     if section3_col_name in cache:
@@ -193,6 +208,8 @@ def run_full_audit(
         print(f"  done ({time.monotonic() - t0:.1f}s)", file=sys.stderr)
         cache[section3_col_name] = report[section3_col_name]
         _save_cache(org, cache, cache_storage)
+
+    print("\n Collecting GitHub Actions Posture Data...", file=sys.stderr)
 
     report["4_actions_posture"] = {
         "details": {
@@ -219,6 +236,7 @@ def run_full_audit(
         }
     }
 
+    print("\n Collecting Webhooks and GitHub Apps Data...", file=sys.stderr)
     report["5_webhooks_integrations"] = {
         "details": {
             "webhooks": {
@@ -237,6 +255,8 @@ def run_full_audit(
         }
     }
 
+    print("\n Collecting Organization Rulesets Data...", file=sys.stderr)
+
     report["6_rulesets"] = {
         "details": {
             "access": "ok",
@@ -249,6 +269,7 @@ def run_full_audit(
 
 
 def write_excel(report: dict[str, Any], path: str) -> None:
+    """Write the org security posture report to an Excel file."""
     summary = build_org_security_summary(report)
     summary_df = pd.DataFrame(list(summary.items()), columns=["metric", "value"])
 
@@ -288,101 +309,65 @@ def write_excel(report: dict[str, Any], path: str) -> None:
         report.get("6_rulesets", {}).get("details", {}).get("rulesets", [])
     )
 
+    # Map sheet names to DataFrames for writing
+    sheet_to_df_mapping = {
+        "Summary": summary_df,
+        "Org Settings": overview_df,
+        "2FA Disabled": mfa_df,
+        "Outside Collaborators": collabs_df,
+        "Teams": teams_df,
+        "Code Scanning Alerts": code_df,
+        "Secret Scanning Alerts": secret_df,
+        "Supply Chain": deps_df,
+        "Runners": runners_df,
+        "Org Credentials": credentials_df,
+        "Webhooks": hooks_df,
+        "GitHub Apps": apps_df,
+        "Rulesets": rulesets_df,
+    }
+
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
-        summary_df.to_excel(writer, index=False, sheet_name="Summary")
-        if not overview_df.empty:
-            overview_df.to_excel(writer, index=False, sheet_name="Org Settings")
-        if not mfa_df.empty:
-            mfa_df.to_excel(writer, index=False, sheet_name="2FA Disabled")
-        if not collabs_df.empty:
-            collabs_df.to_excel(writer, index=False, sheet_name="Outside Collaborators")
-        if not teams_df.empty:
-            teams_df.to_excel(writer, index=False, sheet_name="Teams")
-        if not code_df.empty:
-            code_df.to_excel(writer, index=False, sheet_name="Code Scanning Alerts")
-        if not secret_df.empty:
-            secret_df.to_excel(writer, index=False, sheet_name="Secret Scanning Alerts")
-        if not deps_df.empty:
-            deps_df.to_excel(writer, index=False, sheet_name="Supply Chain")
-        if not runners_df.empty:
-            runners_df.to_excel(writer, index=False, sheet_name="Runners")
-        if not credentials_df.empty:
-            credentials_df.to_excel(writer, index=False, sheet_name="Org Credentials")
-        if not hooks_df.empty:
-            hooks_df.to_excel(writer, index=False, sheet_name="Webhooks")
-        if not apps_df.empty:
-            apps_df.to_excel(writer, index=False, sheet_name="GitHub Apps")
-        if not rulesets_df.empty:
-            rulesets_df.to_excel(writer, index=False, sheet_name="Rulesets")
+        for sheet_name, df in sheet_to_df_mapping.items():
+            if not df.empty:
+                print(f"Writing sheet: {sheet_name} ({len(df)} rows)", file=sys.stderr)
+                df.to_excel(writer, index=False, sheet_name=sheet_name)
+            else:
+                print(f"Skipping empty sheet: {sheet_name}", file=sys.stderr)
 
     print(f"Wrote {path}", file=sys.stderr)
 
 
 def main() -> None:
+    """Main entry point for org security posture audit script."""
     global __start_time
     __start_time = time.monotonic()
 
     args = _parse_args()
 
-    config: AuditConfig = load_audit_config(args.config_file)
-
-    org_security_posture_config = config.org_security_posture
-
-    # Define Variables from Config
-    database_path = org_security_posture_config.database_path
-    if database_path is not None and not Path(database_path).is_absolute():
-        database_path = str(Path(PROJECT_ROOT) / database_path)
-    github_organization = config.github_organization
-    output_filename = org_security_posture_config.output_filename
-    repo_file = config.repo_list_file
-    if repo_file is not None and not Path(repo_file).is_absolute():
-        repo_file = str(Path(PROJECT_ROOT) / repo_file)
-    resume = org_security_posture_config.resume
-
-    # Org Security Posture Debug
-    print(section_break, file=sys.stderr)
-
-    print(
-        "org_security_posture to be executed with the following config values:",
-        file=sys.stderr,
-    )
-
-    print(section_break, file=sys.stderr)
-
-    print(f"Database Path: {database_path}", file=sys.stderr)
-    print(f"GitHub Organization: {github_organization}", file=sys.stderr)
-    print(f"Output Filename: {output_filename}", file=sys.stderr)
-    print(f"Repo File: {repo_file}", file=sys.stderr)
-    print(f"Resume: {resume}", file=sys.stderr)
-
-    print(sub_section_break, file=sys.stderr)
-
     repo_scope: list[str] | None = None
-    if repo_file:
+    if args.repo_file:
         try:
-            repo_scope = load_repo_list_file(repo_file)
+            repo_scope = load_repo_list_file(args.repo_file)
         except Exception as exc:
             print(f"Failed to read repo file: {exc}", file=sys.stderr)
             sys.exit(2)
 
-        org_prefix = f"{github_organization}/"
+        org_prefix = f"{args.org}/"
         repo_scope = [name for name in repo_scope if name.startswith(org_prefix)]
         print(
-            f"Using {len(repo_scope)} repos from {repo_file} for supply-chain checks",
+            f"Using {len(repo_scope)} repos from {args.repo_file} for supply-chain checks",
             file=sys.stderr,
         )
 
-    print(
-        f"Running org security posture audit for: {github_organization}",
-        file=sys.stderr,
-    )
+    print(f"Running org security posture audit for: {args.org}", file=sys.stderr)
     report = run_full_audit(
-        github_organization,
+        args.org,
         args.auth,
         repo_full_names=repo_scope,
-        use_cache=resume,
+        use_cache=not args.no_cache,
     )
 
+    print("\n Audit complete. Building summary...", file=sys.stderr)
     summary = build_org_security_summary(report)
     _SAFE_SUMMARY_KEYS = (
         "org_name",
@@ -413,8 +398,9 @@ def main() -> None:
         if key in summary:
             print(f"  {key}: {summary[key]}", file=sys.stderr)
 
-    excel_path = os.path.join(OUTPUT_DIR, output_filename)
-    write_excel(report, excel_path)
+    if args.excel:
+        excel_path = os.path.join(OUTPUT_DIR, args.excel)
+        write_excel(report, excel_path)
 
 
 if __name__ == "__main__":

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -77,11 +77,6 @@ def _parse_args() -> argparse.Namespace:
         help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     parser.add_argument(
-        "--no-cache",
-        action="store_true",
-        help="Ignore on-disk posture cache and fetch fresh data.",
-    )
-    parser.add_argument(
         "--auth",
         choices=["pat", "app", "cli"],
         default=None,
@@ -119,7 +114,7 @@ def run_full_audit(
     org: str,
     auth_method: Literal["pat", "app", "cli"] | None = None,
     repo_full_names: list[str] | None = None,
-    use_cache: bool = True,
+    use_cache: bool = False,
 ) -> dict[str, Any]:
     """Run a full audit for the given organization."""
     cache_storage = SqliteOrgStorage(ORG_CACHE_DB_PATH)
@@ -352,6 +347,7 @@ def main() -> None:
     github_organization = config.github_organization
     output_filename = org_security_posture_config.output_filename
     repo_file = config.repo_list_file
+    resume = org_security_posture_config.resume
 
     if repo_file is not None and not Path(repo_file).is_absolute():
         repo_file = str(Path(PROJECT_ROOT) / repo_file)
@@ -366,12 +362,12 @@ def main() -> None:
 
     print(section_break, file=sys.stderr)
 
+    print(f"Auth method: {args.auth}", file=sys.stderr)
     print(f"Database Path: {database_path}", file=sys.stderr)
     print(f"GitHub Organization: {github_organization}", file=sys.stderr)
     print(f"Using repo file: {repo_file}", file=sys.stderr)
     print(f"Output filename: {output_filename}", file=sys.stderr)
-    print(f"No-cache: {args.no_cache}", file=sys.stderr)
-    print(f"Auth method: {args.auth}", file=sys.stderr)
+    print(f"Resume: {resume}", file=sys.stderr)
 
     print(sub_section_break, file=sys.stderr)
 
@@ -397,11 +393,15 @@ def main() -> None:
         github_organization,
         args.auth,
         repo_full_names=repo_scope,
-        use_cache=not args.no_cache,
+        use_cache=resume,
     )
 
     print("\n Audit complete. Building summary...", file=sys.stderr)
     summary = build_org_security_summary(report)
+
+    # Keys considered safe to print in full without redaction - i.e. not expected to contain sensitive info and
+    # useful for debugging/summary purposes. This is not an exhaustive list of all non-sensitive keys,
+    # just a curated subset for quick reference in logs.
     _SAFE_SUMMARY_KEYS = (
         "org_name",
         "public_repos",
@@ -426,6 +426,7 @@ def main() -> None:
         "installed_github_apps",
         "org_rulesets_count",
     )
+
     print("\n=== SECURITY POSTURE SUMMARY ===", file=sys.stderr)
     for key in _SAFE_SUMMARY_KEYS:
         if key in summary:

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -341,9 +341,12 @@ def main() -> None:
     org_security_posture_config = config.org_security_posture
 
     # Define Variables from Config
-    database_path = org_security_posture_config.database_path
-    if database_path is not None and not Path(database_path).is_absolute():
-        database_path = str(Path(PROJECT_ROOT) / database_path)
+    database_path = Path(org_security_posture_config.database_path)
+    if not database_path.is_absolute():
+        database_path = Path(PROJECT_ROOT) / database_path
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    global ORG_CACHE_DB_PATH
+    ORG_CACHE_DB_PATH = str(database_path)
     github_organization = config.github_organization
     output_filename = org_security_posture_config.output_filename
     repo_file = config.repo_list_file

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -8,6 +8,7 @@ import atexit
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any, Literal
 
 # add project root to path for core imports
@@ -17,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
 
 from core.collector import OrgEndpointCollector
+from core.config import load_audit_config, AuditConfig
 from core.github_api import (
     OrgActionsEndpoint,
     OrgAuditLogEndpoint,
@@ -36,6 +38,9 @@ from core.repo_list import load_repo_list_file
 from core.storage import SqliteOrgStorage
 from core.utils import base_directory_setup
 
+section_break = "\n" + ("=" * 80) + "\n"
+sub_section_break = "\n" + ("-" * 80) + "\n"
+
 # TODO:
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 
@@ -45,9 +50,6 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # Set Default Cache and Repo List Paths
 ORG_CACHE_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "org_posture_cache.db")
-
-# TODO: Remove hardcoded YAML_FILE once repo list loading updated to use audit_config.yaml for default with CLI override
-DEFAULT_REPO_FILE = os.path.join(PROJECT_ROOT, "repo_list.yaml")
 
 __start_time: float | None = None
 
@@ -66,21 +68,11 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Audit organisation security posture using core collectors."
     )
-    parser.add_argument("org", help="GitHub organisation login.")
-    parser.add_argument("--excel", help="Write Excel workbook output.")
     parser.add_argument(
-        "--repo-file",
-        nargs="?",
-        const=DEFAULT_REPO_FILE,
-        help=(
-            "Limit supply-chain checks to repos in a file. "
-            "Pass a path, or use --repo-file without a value to default to repo_list.yaml."
-        ),
-    )
-    parser.add_argument(
-        "--no-cache",
-        action="store_true",
-        help="Ignore on-disk posture cache and fetch fresh data.",
+        "--config-file",
+        default=None,
+        type=Path,
+        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     parser.add_argument(
         "--auth",
@@ -122,7 +114,11 @@ def run_full_audit(
 ) -> dict[str, Any]:
     cache_storage = SqliteOrgStorage(ORG_CACHE_DB_PATH)
     cache_storage.init()
-    cache = _load_cache(org, cache_storage) if use_cache else {}
+    cache = (
+        _load_cache(org, cache_storage)
+        if use_cache
+        else {print("  use_cache is False, fetching fresh data...", file=sys.stderr)}
+    )
     client = GitHubHttpClient(auth_method)
 
     report: dict[str, Any] = {
@@ -328,27 +324,63 @@ def main() -> None:
 
     args = _parse_args()
 
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    org_security_posture_config = config.org_security_posture
+
+    # Define Variables from Config
+    database_path = org_security_posture_config.database_path
+    if database_path is not None and not Path(database_path).is_absolute():
+        database_path = str(Path(PROJECT_ROOT) / database_path)
+    github_organization = config.github_organization
+    output_filename = org_security_posture_config.output_filename
+    repo_file = config.repo_list_file
+    if repo_file is not None and not Path(repo_file).is_absolute():
+        repo_file = str(Path(PROJECT_ROOT) / repo_file)
+    resume = org_security_posture_config.resume
+
+    # Org Security Posture Debug
+    print(section_break, file=sys.stderr)
+
+    print(
+        "org_security_posture to be executed with the following config values:",
+        file=sys.stderr,
+    )
+
+    print(section_break, file=sys.stderr)
+
+    print(f"Database Path: {database_path}", file=sys.stderr)
+    print(f"GitHub Organization: {github_organization}", file=sys.stderr)
+    print(f"Output Filename: {output_filename}", file=sys.stderr)
+    print(f"Repo File: {repo_file}", file=sys.stderr)
+    print(f"Resume: {resume}", file=sys.stderr)
+
+    print(sub_section_break, file=sys.stderr)
+
     repo_scope: list[str] | None = None
-    if args.repo_file:
+    if repo_file:
         try:
-            repo_scope = load_repo_list_file(args.repo_file)
+            repo_scope = load_repo_list_file(repo_file)
         except Exception as exc:
             print(f"Failed to read repo file: {exc}", file=sys.stderr)
             sys.exit(2)
 
-        org_prefix = f"{args.org}/"
+        org_prefix = f"{github_organization}/"
         repo_scope = [name for name in repo_scope if name.startswith(org_prefix)]
         print(
-            f"Using {len(repo_scope)} repos from {args.repo_file} for supply-chain checks",
+            f"Using {len(repo_scope)} repos from {repo_file} for supply-chain checks",
             file=sys.stderr,
         )
 
-    print(f"Running org security posture audit for: {args.org}", file=sys.stderr)
+    print(
+        f"Running org security posture audit for: {github_organization}",
+        file=sys.stderr,
+    )
     report = run_full_audit(
-        args.org,
+        github_organization,
         args.auth,
         repo_full_names=repo_scope,
-        use_cache=not args.no_cache,
+        use_cache=resume,
     )
 
     summary = build_org_security_summary(report)
@@ -381,9 +413,8 @@ def main() -> None:
         if key in summary:
             print(f"  {key}: {summary[key]}", file=sys.stderr)
 
-    if args.excel:
-        excel_path = os.path.join(OUTPUT_DIR, args.excel)
-        write_excel(report, excel_path)
+    excel_path = os.path.join(OUTPUT_DIR, output_filename)
+    write_excel(report, excel_path)
 
 
 if __name__ == "__main__":

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -350,7 +350,7 @@ def main() -> None:
     github_organization = config.github_organization
     output_filename = org_security_posture_config.output_filename
     repo_file = config.repo_list_file
-    resume = org_security_posture_config.resume
+    use_cache = org_security_posture_config.use_cache
 
     if repo_file is not None and not Path(repo_file).is_absolute():
         repo_file = str(Path(PROJECT_ROOT) / repo_file)
@@ -370,7 +370,7 @@ def main() -> None:
     print(f"GitHub Organization: {github_organization}", file=sys.stderr)
     print(f"Using repo file: {repo_file}", file=sys.stderr)
     print(f"Output filename: {output_filename}", file=sys.stderr)
-    print(f"Resume: {resume}", file=sys.stderr)
+    print(f"Use Cache: {use_cache}", file=sys.stderr)
 
     print(sub_section_break, file=sys.stderr)
 
@@ -396,7 +396,7 @@ def main() -> None:
         github_organization,
         args.auth,
         repo_full_names=repo_scope,
-        use_cache=resume,
+        use_cache=use_cache,
     )
 
     print("\n Audit complete. Building summary...", file=sys.stderr)

--- a/scripts/org_security_posture.py
+++ b/scripts/org_security_posture.py
@@ -8,6 +8,7 @@ import atexit
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any, Literal
 
 # add project root to path for core imports
@@ -17,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
 
 from core.collector import OrgEndpointCollector
+from core.config import AuditConfig, load_audit_config
 from core.github_api import (
     OrgActionsEndpoint,
     OrgAuditLogEndpoint,
@@ -36,6 +38,9 @@ from core.repo_list import load_repo_list_file
 from core.storage import SqliteOrgStorage
 from core.utils import base_directory_setup
 
+section_break = "\n" + ("=" * 80) + "\n"
+sub_section_break = "\n" + ("-" * 80) + "\n"
+
 # TODO:
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 
@@ -45,9 +50,6 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # Set Default Cache and Repo List Paths
 ORG_CACHE_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "org_posture_cache.db")
-
-# TODO: Remove hardcoded YAML_FILE once repo list loading updated to use audit_config.yaml for default with CLI override
-DEFAULT_REPO_FILE = os.path.join(PROJECT_ROOT, "repo_list.yaml")
 
 __start_time: float | None = None
 
@@ -68,16 +70,11 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Audit organisation security posture using core collectors."
     )
-    parser.add_argument("org", help="GitHub organisation login.")
-    parser.add_argument("--excel", help="Write Excel workbook output.")
     parser.add_argument(
-        "--repo-file",
-        nargs="?",
-        const=DEFAULT_REPO_FILE,
-        help=(
-            "Limit supply-chain checks to repos in a file. "
-            "Pass a path, or use --repo-file without a value to default to repo_list.yaml."
-        ),
+        "--config-file",
+        default=None,
+        type=Path,
+        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
     )
     parser.add_argument(
         "--no-cache",
@@ -344,24 +341,60 @@ def main() -> None:
 
     args = _parse_args()
 
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    org_security_posture_config = config.org_security_posture
+
+    # Define Variables from Config
+    database_path = org_security_posture_config.database_path
+    if database_path is not None and not Path(database_path).is_absolute():
+        database_path = str(Path(PROJECT_ROOT) / database_path)
+    github_organization = config.github_organization
+    output_filename = org_security_posture_config.output_filename
+    repo_file = config.repo_list_file
+
+    if repo_file is not None and not Path(repo_file).is_absolute():
+        repo_file = str(Path(PROJECT_ROOT) / repo_file)
+
+    # Org Security Posture Config Debug
+    print(section_break, file=sys.stderr)
+
+    print(
+        "org_security_posture to be executed with the following config values:",
+        file=sys.stderr,
+    )
+
+    print(section_break, file=sys.stderr)
+
+    print(f"Database Path: {database_path}", file=sys.stderr)
+    print(f"GitHub Organization: {github_organization}", file=sys.stderr)
+    print(f"Using repo file: {repo_file}", file=sys.stderr)
+    print(f"Output filename: {output_filename}", file=sys.stderr)
+    print(f"No-cache: {args.no_cache}", file=sys.stderr)
+    print(f"Auth method: {args.auth}", file=sys.stderr)
+
+    print(sub_section_break, file=sys.stderr)
+
     repo_scope: list[str] | None = None
-    if args.repo_file:
-        try:
-            repo_scope = load_repo_list_file(args.repo_file)
-        except Exception as exc:
-            print(f"Failed to read repo file: {exc}", file=sys.stderr)
-            sys.exit(2)
+    try:
+        repo_scope = load_repo_list_file(repo_file)
+    except Exception as exc:
+        print(f"Failed to read repo file: {exc}", file=sys.stderr)
+        sys.exit(2)
 
-        org_prefix = f"{args.org}/"
-        repo_scope = [name for name in repo_scope if name.startswith(org_prefix)]
-        print(
-            f"Using {len(repo_scope)} repos from {args.repo_file} for supply-chain checks",
-            file=sys.stderr,
-        )
+    org_prefix = f"{github_organization}/"
+    repo_scope = [name for name in repo_scope if name.startswith(org_prefix)]
+    print(
+        f"Using {len(repo_scope)} repos from {repo_file} for supply-chain checks",
+        file=sys.stderr,
+    )
 
-    print(f"Running org security posture audit for: {args.org}", file=sys.stderr)
+    print(
+        f"Running org security posture audit for: {github_organization}",
+        file=sys.stderr,
+    )
     report = run_full_audit(
-        args.org,
+        github_organization,
         args.auth,
         repo_full_names=repo_scope,
         use_cache=not args.no_cache,
@@ -398,9 +431,8 @@ def main() -> None:
         if key in summary:
             print(f"  {key}: {summary[key]}", file=sys.stderr)
 
-    if args.excel:
-        excel_path = os.path.join(OUTPUT_DIR, args.excel)
-        write_excel(report, excel_path)
+    excel_path = os.path.join(OUTPUT_DIR, output_filename)
+    write_excel(report, excel_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,15 +41,57 @@ def test_load_returns_config_from_file(tmp_path):
     assert config.repo_list_file == "custom_repos.yaml"
 
 
-# TODO: add similar test to test_load_respects_stage_toggles to check list_repos
-# toggles are respected
+def test_load_respects_org_security_posture_config_overrides(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "repo_list_file": "custom_repos.yaml",
+                "org_security_posture": {
+                    "database_path": "custom_org_posture.db",
+                    "output_filename": "custom_org_posture.xlsx",
+                    "use_cache": False,
+                },
+            }
+        )
+    )
 
-# TODO: add similar test to test_load_respects_stage_toggles to check org_security_posture
-# toggles are respected
+    config = load_audit_config(config_file)
+
+    assert config.repo_list_file == "custom_repos.yaml"
+    assert config.org_security_posture.database_path == "custom_org_posture.db"
+    assert config.org_security_posture.output_filename == "custom_org_posture.xlsx"
+    assert config.org_security_posture.use_cache is False
 
 
-# TODO: rename to focus on workflow_audit toggles
-def test_load_respects_stage_toggles(tmp_path):
+def test_load_respects_list_repos_config_overrides(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "repo_list_file": "custom_list_repos_repos.yaml",
+                "list_repos": {
+                    "output_filename": "custom_list_repos_output.xlsx",
+                    "use_cache": False,
+                    "standard_endpoints_only": False,
+                    "sort_by_field": "created_at",
+                    "sort_ascending": True,
+                },
+            }
+        )
+    )
+
+    config = load_audit_config(config_file)
+
+    assert config.repo_list_file == "custom_list_repos_repos.yaml"
+    assert config.list_repos.output_filename == "custom_list_repos_output.xlsx"
+    assert config.list_repos.use_cache is False
+    assert config.list_repos.standard_endpoints_only is False
+    assert config.list_repos.sort_by_field == "created_at"
+    assert config.list_repos.sort_ascending is True
+
+
+def test_load_respects_workflow_audit_config_overrides(tmp_path):
     config_file = tmp_path / "audit_config.yaml"
     config_file.write_text(
         yaml.safe_dump(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,14 @@ def test_load_returns_config_from_file(tmp_path):
     assert config.repo_list_file == "custom_repos.yaml"
 
 
+# TODO: add similar test to test_load_respects_stage_toggles to check list_repos
+# toggles are respected
+
+# TODO: add similar test to test_load_respects_stage_toggles to check org_security_posture
+# toggles are respected
+
+
+# TODO: rename to focus on workflow_audit toggles
 def test_load_respects_stage_toggles(tmp_path):
     config_file = tmp_path / "audit_config.yaml"
     config_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -184,11 +184,12 @@ wheels = [
 
 [[package]]
 name = "dash"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "importlib-metadata" },
+    { name = "janus" },
     { name = "nest-asyncio" },
     { name = "plotly" },
     { name = "requests" },
@@ -197,9 +198,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/da/a13ae3a6528bd51a6901461dbff4549c6009de203d6249a89b9a09ac5cfb/dash-4.1.0.tar.gz", hash = "sha256:17a92a87b0c1eacc025079a705e44e72cd4c5794629c0a2909942b611faeb595", size = 6927689, upload-time = "2026-03-23T20:39:47.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/25/90e909e6605445b7348a5453f1b242af7e1f2eb4220497b561874d9bc121/dash-4.2.0.tar.gz", hash = "sha256:53c959f8f5d5a1cc79995f097211e9f4c7039db715fe7d88de4e874c0652cf54", size = 6912113, upload-time = "2026-06-01T20:44:21.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/00/10b1f8b3885fc4add1853e9603af15c593fa0be20d37c158c4d811e868dc/dash-4.1.0-py3-none-any.whl", hash = "sha256:1af9f302bc14061061012cdb129b7e370d3604b12a7f730b252ad8e4966f01f7", size = 7232489, upload-time = "2026-03-23T20:39:40.658Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/fb/1be45ee9bfbf2c468de35f9d94e7896ed0fdff3413f916b788932093204e/dash-4.2.0-py3-none-any.whl", hash = "sha256:12e0bc347643b31a22237b7049e999cf96386790ff23d2d4f98e07d575c67538", size = 7256065, upload-time = "2026-06-01T20:44:18.723Z" },
 ]
 
 [[package]]
@@ -230,11 +231,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -265,6 +266,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "janus"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/7f/69884b6618be4baf6ebcacc716ee8680a842428a19f403db6d1c0bb990aa/janus-2.0.0.tar.gz", hash = "sha256:0970f38e0e725400496c834a368a67ee551dc3b5ad0a257e132f5b46f2e77770", size = 22910, upload-time = "2024-12-13T12:59:08.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/34/65604740edcb20e1bda6a890348ed7d282e7dd23aa00401cbe36fd0edbd9/janus-2.0.0-py3-none-any.whl", hash = "sha256:7e6449d34eab04cd016befbd7d8c0d8acaaaab67cb59e076a69149f9031745f9", size = 12161, upload-time = "2024-12-13T12:59:06.106Z" },
 ]
 
 [[package]]
@@ -350,11 +360,11 @@ dev = [
 
 [[package]]
 name = "narwhals"
-version = "2.21.2"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/a0/6198c56d42ef2f3c6ed0c42ba30dbcefdc86a91262d7d449010770ae085b/narwhals-2.21.2.tar.gz", hash = "sha256:5c5b2d0b47aef7c73ea412cfcbcd467f2f2d5be73e3c2ab19d78f4a97718790a", size = 632176, upload-time = "2026-05-16T08:49:08.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/1c/c80cb7719721a44846c6301ef118434bae30a423924bfad3a47f16bdc064/narwhals-2.22.0.tar.gz", hash = "sha256:6486282bb7e4b4ab55963efbd8be1451b764cc4874b74d1fd625eba9dc60b86f", size = 417565, upload-time = "2026-06-01T13:34:36.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/77/928ea2e70641ca177a11140062cc5840d421795f2e82749d408d0cce900a/narwhals-2.21.2-py3-none-any.whl", hash = "sha256:7bb57c3700486039215455b9bf2d64261915cc0fd845cc30272d631df696b251", size = 451201, upload-time = "2026-05-16T08:49:05.536Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b6/e7cdde7b8e90d5dff25b622f95833ef26567ad184c977278b93a1cbd5717/narwhals-2.22.0-py3-none-any.whl", hash = "sha256:1421797ede01789cc1537619dbc3f36f840737240f748fdb24a60a0225fc80be", size = 453815, upload-time = "2026-06-01T13:34:34.127Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Introduction :pencil2:

Resolves / closes #132 by wiring `scripts/org_security_posture.py` to the newly established audit config workflow

## Resolution :heavy_check_mark:

- Added org_security_posture configuration schema to `core/config.py` and corresponding defaults in config/audit_config.yaml.
- Updated scripts/org_security_posture.py to load org/security-posture settings from `audit_config.yaml` (and added --config-file).
- Refactored Excel writing to use a sheet→DataFrame mapping loop.


File | Description
-- | --
uv.lock | Dependency lock updates (dash/idna bumps; adds janus).
core/config.py | Adds OrgSecurityPostureConfig; renames ListReposConfig.resume → use_cache.
config/audit_config.yaml | Adds org_security_posture defaults; updates list_repos flag name.
scripts/org_security_posture.py | Loads org posture settings from YAML; refactors Excel writing; adds --config-file.
scripts/list_repos.py | Wires use_cache from config into collection flow.
tests/test_config.py | Adds coverage for new org_security_posture config + list_repos overrides.
README.md | Updates usage/docs for config-driven execution.
core/transforms.py | Removes duplicated constant definition.

