### PR TITLE
Extend YAML Config Support: lfs_script.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,21 @@ It generates a master Excel summary of repos exceeding thresholds and individual
 **Usage:**
 
 ```bash
-uv run python scripts/lfs_script.py
+uv run python scripts/lfs_script.py --config-file config/audit_config.yaml --auth pat
 ```
+
+**CLI Options:**
+
+- `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
+- `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.
+
+**Config Parameters:**
+
+- `database_path`: SQLite path for core storage (default: `internal/lfs_audit.db`).
+- `soft_limit_mb: <int>`: Integer soft/warning file size limit in Megabytes. Defaults to 50.
+- `hard_limit_mb: <int>`: Integer hard file size limit in Megabytes. Defaults to 100.
+- `output_filename: <filename>.xlsx` - Filename for summary output Excel File under `output/lfs_analysis`
+- `use_cache: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 
 **Output:**
 

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -33,3 +33,9 @@ workflow_audit:
   permissions_analysis: true     # stage 7 - workflow permissions
   credentials_analysis: true     # stage 8 - OIDC vs long-lived
   trigger_risk_analysis: true    # stage 9 - trigger config risk
+
+lfs_script:
+  database_path: "internal/lfs_audit.db"
+  soft_limit_mb: 50
+  hard_limit_mb: 100
+  output_csv_filename: "repos_exceeding_thresholds.xlsx"

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -39,5 +39,5 @@ lfs_script:
   database_path: "internal/lfs_audit.db"
   soft_limit_mb: 50
   hard_limit_mb: 100
-  output_csv_filename: "repos_exceeding_thresholds.xlsx"
+  output_filename: "repos_exceeding_thresholds.xlsx"
   use_cache: false

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -34,8 +34,10 @@ workflow_audit:
   credentials_analysis: true     # stage 8 - OIDC vs long-lived
   trigger_risk_analysis: true    # stage 9 - trigger config risk
 
+# Script config for lfs_script.py.
 lfs_script:
   database_path: "internal/lfs_audit.db"
   soft_limit_mb: 50
   hard_limit_mb: 100
   output_csv_filename: "repos_exceeding_thresholds.xlsx"
+  use_cache: false

--- a/core/config.py
+++ b/core/config.py
@@ -22,7 +22,7 @@ class LfsScriptConfig(BaseModel):
     database_path: str = "internal/lfs_audit.db"  # SQLite cache file for LFS audit data
     soft_limit_mb: int = 50  # soft file size limit in megabytes
     hard_limit_mb: int = 100  # hard file size limit in megabytes
-    output_csv_filename: str = (
+    output_filename: str = (
         "repos_exceeding_thresholds.xlsx"  # output file for repos exceeding limits
     )
     use_cache: bool = (

--- a/core/config.py
+++ b/core/config.py
@@ -25,6 +25,9 @@ class LfsScriptConfig(BaseModel):
     output_csv_filename: str = (
         "repos_exceeding_thresholds.xlsx"  # output file for repos exceeding limits
     )
+    use_cache: bool = (
+        True  # whether to use database cache to skip repos already collected
+    )
 
 
 class ListReposConfig(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -16,6 +16,17 @@ from pydantic import BaseModel, Field
 DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 
 
+class LfsScriptConfig(BaseModel):
+    """Config for ``lfs_audit.py`` script."""
+
+    database_path: str = "internal/lfs_audit.db"  # SQLite cache file for LFS audit data
+    soft_limit_mb: int = 50  # soft file size limit in megabytes
+    hard_limit_mb: int = 100  # hard file size limit in megabytes
+    output_csv_filename: str = (
+        "repos_exceeding_thresholds.xlsx"  # output file for repos exceeding limits
+    )
+
+
 class ListReposConfig(BaseModel):
     """Config for ``list_repos.py`` script."""
 
@@ -65,6 +76,7 @@ class AuditConfig(BaseModel):
 
     github_organization: str = "ministryofjustice"
     repo_list_file: str = "repo_list.yaml"
+    lfs_script: LfsScriptConfig = Field(default_factory=LfsScriptConfig)
     list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
     org_security_posture: OrgSecurityPostureConfig = Field(
         default_factory=OrgSecurityPostureConfig

--- a/core/config.py
+++ b/core/config.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 
 
 class LfsScriptConfig(BaseModel):
-    """Config for ``lfs_audit.py`` script."""
+    """Config for ``lfs_script.py`` script."""
 
     database_path: str = "internal/lfs_audit.db"  # SQLite cache file for LFS audit data
     soft_limit_mb: int = 50  # soft file size limit in megabytes

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -27,10 +27,6 @@ import re
 
 from core.models import LargeBlobData, RepoData, RepoTreeProcessedData
 
-# Size limits in bytes (50/100 MB converted to bytes for ease of processing)
-SOFT_LIMIT = 50 * 1024 * 1024
-HARD_LIMIT = 100 * 1024 * 1024
-
 
 # ── Abstract base ─────────────────────────────────────────────────────
 
@@ -206,6 +202,10 @@ class RepoTreeTransform(BaseTransform):
     * ``exceeds_hard_limit`` — whether the largest blob exceeds the hard limit
     """
 
+    def __init__(self, soft_limit_mb: int, hard_limit_mb: int):
+        self.soft_limit_bytes = soft_limit_mb * 1024 * 1024
+        self.hard_limit_bytes = hard_limit_mb * 1024 * 1024
+
     @property
     def name(self) -> str:
         return "repo_tree_transform"
@@ -234,6 +234,8 @@ class RepoTreeTransform(BaseTransform):
     def process_repo_tree_stats(
         repo_full_name: str,
         tree: list[object],
+        soft_limit_bytes: int,
+        hard_limit_bytes: int,
     ) -> RepoTreeProcessedData:
         large_blobs: list[LargeBlobData] = []
 
@@ -244,7 +246,7 @@ class RepoTreeTransform(BaseTransform):
             path = getattr(item, "path", None)
             if not isinstance(size, int) or not isinstance(path, str):
                 continue
-            if size >= SOFT_LIMIT:
+            if size >= soft_limit_bytes:
                 large_blobs.append(
                     LargeBlobData(
                         sha=getattr(item, "sha", None),
@@ -262,17 +264,19 @@ class RepoTreeTransform(BaseTransform):
             largest_blob_bytes=largest_size,
             largest_blob_path=largest_path,
             large_blobs=large_blobs,
-            exceeds_soft_limit=largest_size > SOFT_LIMIT,
-            exceeds_hard_limit=largest_size > HARD_LIMIT,
+            exceeds_soft_limit=largest_size > soft_limit_bytes,
+            exceeds_hard_limit=largest_size > hard_limit_bytes,
         )
 
     def apply(self, data: RepoData) -> RepoData:
         if data.repo_tree is None or data.repo_details is None:
             return data
 
-        processed = self.process_repo_tree_stats(
+        processed = RepoTreeTransform.process_repo_tree_stats(
             data.repo_details.full_name,
             data.repo_tree.tree,
+            soft_limit_bytes=self.soft_limit_bytes,
+            hard_limit_bytes=self.hard_limit_bytes,
         )
 
         return data.model_copy(update={"repo_tree_transform": processed})

--- a/scripts/lfs_script.py
+++ b/scripts/lfs_script.py
@@ -134,7 +134,8 @@ def main():
         database_path = os.path.join(PROJECT_ROOT, database_path)
     github_organization = config.github_organization
     output_filename = lfs_script_config.output_filename
-    if output_filename is not None and not os.path.isabs(output_filename):
+    output_file_path = output_filename
+    if not os.path.isabs(output_filename):
         output_file_path = os.path.join(OUTPUT_DIR, output_filename)
     repo_list_file = config.repo_list_file
     if repo_list_file is not None and not os.path.isabs(repo_list_file):

--- a/scripts/lfs_script.py
+++ b/scripts/lfs_script.py
@@ -5,8 +5,10 @@ and generates summary reports in CSV format.
 """
 
 import argparse
+import atexit
 import os
 import sys
+import time
 
 # add project root to path for core imports
 # TODO: Remove once pyproject.toml is build-system configured
@@ -14,6 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pandas as pd
 
+from core.config import AuditConfig, load_audit_config
 from core.models import FieldDefinition, FieldsConfig, FieldType
 from core.collector import RepoCollector
 from core.github_api import GetRepoTreeEndpoint, RepoDetailsEndpoint
@@ -23,9 +26,10 @@ from core.compiler import ExcelCompiler
 from core.transforms import RepoTreeTransform
 from core.utils import base_directory_setup
 
-# GitHub thresholds (bytes)
-SOFT_LIMIT = 50 * 1024 * 1024
-HARD_LIMIT = 100 * 1024 * 1024
+from pathlib import Path
+
+section_break = "\n" + ("=" * 80) + "\n"
+sub_section_break = "\n" + ("-" * 80) + "\n"
 
 # Base directory configurations
 # TODO: PROJECT_ROOT will be removed as an output of base_directory_setup once all scripts updated to use audit_config.yaml for repo_list loading
@@ -36,18 +40,32 @@ OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, "lfs_analysis")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # File paths for input and output
-# TODO: Remove hardcoded YAML_FILE once repo list loading updated to use audit_config.yaml for default with CLI override
-YAML_FILE = os.path.join(PROJECT_ROOT, "repo_list.yaml")
-
-DB_FILE = os.path.join(BASE_INTERNAL_DIR, "repo_list.db")
 REPO_SUMMARIES_DIR = os.path.join(OUTPUT_DIR, "repo_summaries")
-MASTER_CSV = os.path.join(OUTPUT_DIR, "repos_exceeding_thresholds.xlsx")
+MASTER_CSV_PATH = os.path.join(OUTPUT_DIR, "repos_exceeding_thresholds.xlsx")
+
+__start_time: float | None = None
+
+
+# TODO: Consider moving to core.utils as repeated across scripts or to main.py when shared entrypoint developed
+def _report_elapsed() -> None:
+    if __start_time is not None:
+        elapsed = time.monotonic() - __start_time
+        print(f"Elapsed time: {elapsed:.2f}s", file=sys.stderr)
+
+
+atexit.register(_report_elapsed)
 
 
 def parse_args() -> argparse.Namespace:
     """Parse and return command-line arguments for later use within the LFS analysis script."""
     parser = argparse.ArgumentParser(
         description="Analyze GitHub repositories for large file storage (LFS) issues and generate summary reports."
+    )
+    parser.add_argument(
+        "--config-file",
+        type=Path,
+        default=None,
+        help="Path to the audit configuration YAML file (optional, defaults to config/audit_config.yaml)",
     )
     parser.add_argument(
         "--auth",
@@ -100,25 +118,64 @@ def main():
     Loads repository list, collects data from GitHub, generates master summary,
     and creates individual CSV summaries for each repository.
     """
+    global __start_time
+    __start_time = time.monotonic()
+
     print("<LFS Analysis> Starting LFS analysis script", file=sys.stderr)
+
     args = parse_args()
 
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    lfs_script_config = config.lfs_script
+
+    # Define file paths from config
+    database_path = lfs_script_config.database_path
+    if database_path is not None and not os.path.isabs(database_path):
+        database_path = os.path.join(PROJECT_ROOT, database_path)
+    github_organization = config.github_organization
+    output_csv_filename = lfs_script_config.output_csv_filename
+    if output_csv_filename is not None and not os.path.isabs(output_csv_filename):
+        output_csv_path = os.path.join(OUTPUT_DIR, output_csv_filename)
+    repo_list_file = config.repo_list_file
+    if repo_list_file is not None and not os.path.isabs(repo_list_file):
+        repo_list_file = os.path.join(PROJECT_ROOT, repo_list_file)
+
+    soft_limit_mb = lfs_script_config.soft_limit_mb
+    hard_limit_mb = lfs_script_config.hard_limit_mb
+
+    # Variable Debug
+
+    print(section_break, file=sys.stderr)
+    print(
+        "LFS analysis to be executed with the following config values:", file=sys.stderr
+    )
+    print(section_break, file=sys.stderr)
+
+    print(f"Database Path: {database_path}", file=sys.stderr)
+    print(f"GitHub Organization: {github_organization}", file=sys.stderr)
+    print(f"Output CSV Path: {output_csv_path}", file=sys.stderr)
+    print(f"Repo file: {repo_list_file}", file=sys.stderr)
+    print(f"Soft limit (MB): {soft_limit_mb}", file=sys.stderr)
+    print(f"Hard limit (MB): {hard_limit_mb}", file=sys.stderr)
+    print(sub_section_break, file=sys.stderr)
+
     # Ensure the repo list file exists
-    if not os.path.exists(YAML_FILE):
+    if not os.path.exists(repo_list_file):
         print(
-            f"<LFS Analysis> ERROR: Missing repo list file: {YAML_FILE}",
+            f"<LFS Analysis> ERROR: Missing repo list file: {repo_list_file}",
             file=sys.stderr,
         )
-        raise FileNotFoundError(f"Missing repo list file: {YAML_FILE}")
+        raise FileNotFoundError(f"Missing repo list file: {repo_list_file}")
 
     # Load the list of repositories from the YAML file
     print("<LFS Analysis> Loading repository list from YAML file", file=sys.stderr)
-    repos = load_repo_list_file(YAML_FILE)
+    repos = load_repo_list_file(repo_list_file)
     print(f"<LFS Analysis> Loaded {len(repos)} repositories", file=sys.stderr)
 
     # Set up storage and collector for fetching repo data
     print("<LFS Analysis> Setting up storage and collector", file=sys.stderr)
-    storage = SqliteRepoStorage(DB_FILE)
+    storage = SqliteRepoStorage(database_path)
     collector = RepoCollector(
         storage=storage,
         endpoints=[RepoDetailsEndpoint, GetRepoTreeEndpoint],
@@ -126,12 +183,11 @@ def main():
     )
 
     # Collect data for the primary organization and specified repos, resuming if interrupted
-    primary_org = repos[0].split("/", 1)[0]
     print(
-        f"<LFS Analysis> Collecting data for organization: {primary_org}",
+        f"<LFS Analysis> Collecting data for organization: {github_organization}",
         file=sys.stderr,
     )
-    collector.collect(primary_org, repos=repos, resume=True)
+    collector.collect(github_organization, repos=repos, resume=True)
     print("<LFS Analysis> Data collection completed", file=sys.stderr)
 
     # Compile the master Excel file with repos exceeding thresholds
@@ -139,10 +195,10 @@ def main():
     ExcelCompiler().compile(
         storage=storage,
         config=master_csv_config,
-        output_path=MASTER_CSV,
+        output_path=output_csv_path,
         transforms=[RepoTreeTransform()],
     )
-    print(f"<LFS Analysis> Master summary saved to {MASTER_CSV}", file=sys.stderr)
+    print(f"<LFS Analysis> Master summary saved to {output_csv_path}", file=sys.stderr)
 
     # Ensure output directory exists
     if not os.path.isdir(REPO_SUMMARIES_DIR):

--- a/scripts/lfs_script.py
+++ b/scripts/lfs_script.py
@@ -140,9 +140,12 @@ def main():
     repo_list_file = config.repo_list_file
     if repo_list_file is not None and not os.path.isabs(repo_list_file):
         repo_list_file = os.path.join(PROJECT_ROOT, repo_list_file)
+    resume = (
+        lfs_script_config.use_cache
+    )  # Using 'use_cache' to determine if we should resume from existing data
 
-    soft_limit_mb = lfs_script_config.soft_limit_mb
-    hard_limit_mb = lfs_script_config.hard_limit_mb
+    soft_limit_mb = int(lfs_script_config.soft_limit_mb)
+    hard_limit_mb = int(lfs_script_config.hard_limit_mb)
 
     # Variable Debug
 
@@ -158,6 +161,7 @@ def main():
     print(f"Repo file: {repo_list_file}", file=sys.stderr)
     print(f"Soft limit (MB): {soft_limit_mb}", file=sys.stderr)
     print(f"Hard limit (MB): {hard_limit_mb}", file=sys.stderr)
+    print(f"Resume from cache: {resume}", file=sys.stderr)
     print(sub_section_break, file=sys.stderr)
 
     # Ensure the repo list file exists
@@ -187,7 +191,7 @@ def main():
         f"<LFS Analysis> Collecting data for organization: {github_organization}",
         file=sys.stderr,
     )
-    collector.collect(github_organization, repos=repos, resume=True)
+    collector.collect(github_organization, repos=repos, resume=resume)
     print("<LFS Analysis> Data collection completed", file=sys.stderr)
 
     # Compile the master Excel file with repos exceeding thresholds
@@ -196,7 +200,12 @@ def main():
         storage=storage,
         config=master_csv_config,
         output_path=output_csv_path,
-        transforms=[RepoTreeTransform()],
+        transforms=[
+            RepoTreeTransform(
+                soft_limit_mb=soft_limit_mb,
+                hard_limit_mb=hard_limit_mb,
+            )
+        ],
     )
     print(f"<LFS Analysis> Master summary saved to {output_csv_path}", file=sys.stderr)
 
@@ -211,9 +220,9 @@ def main():
     # Generate individual CSV summaries for each repository
     print("<LFS Analysis> Generating individual CSV summaries", file=sys.stderr)
     for full_repo_name in repos:
-        print(
-            f"<LFS Analysis> Processing repository: {full_repo_name}", file=sys.stderr
-        )
+        # print(
+        #     f"<LFS Analysis> Processing repository: {full_repo_name}", file=sys.stderr
+        # )
         # Retrieve stored data for the repo
         data = storage.read(full_repo_name)
         if not data:
@@ -240,10 +249,10 @@ def main():
             REPO_SUMMARIES_DIR, f"{full_repo_name.replace('/', '_')}_summary.csv"
         )
         pd.DataFrame(blob_rows).to_csv(output_file, index=False)
-        print(
-            f"<LFS Analysis> Saved summary for {full_repo_name} to {output_file}",
-            file=sys.stderr,
-        )
+        # print(
+        #     f"<LFS Analysis> Saved summary for {full_repo_name} to {output_file}",
+        #     file=sys.stderr,
+        # )
 
     print("<LFS Analysis> LFS analysis script completed successfully", file=sys.stderr)
 

--- a/scripts/lfs_script.py
+++ b/scripts/lfs_script.py
@@ -41,7 +41,6 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # File paths for input and output
 REPO_SUMMARIES_DIR = os.path.join(OUTPUT_DIR, "repo_summaries")
-MASTER_CSV_PATH = os.path.join(OUTPUT_DIR, "repos_exceeding_thresholds.xlsx")
 
 __start_time: float | None = None
 
@@ -76,8 +75,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-# Configuration for the master CSV file that summarizes repos exceeding thresholds
-master_csv_config = FieldsConfig(
+# Configuration for the master report file that summarizes repos exceeding thresholds
+master_report_config = FieldsConfig(
     fields=[
         FieldDefinition(
             source="repo_details.full_name",
@@ -198,7 +197,7 @@ def main():
     print("<LFS Analysis> Compiling master Excel summary", file=sys.stderr)
     ExcelCompiler().compile(
         storage=storage,
-        config=master_csv_config,
+        config=master_report_config,
         output_path=output_file_path,
         transforms=[
             RepoTreeTransform(
@@ -220,9 +219,9 @@ def main():
     # Generate individual CSV summaries for each repository
     print("<LFS Analysis> Generating individual CSV summaries", file=sys.stderr)
     for full_repo_name in repos:
-        # print(
-        #     f"<LFS Analysis> Processing repository: {full_repo_name}", file=sys.stderr
-        # )
+        print(
+            f"<LFS Analysis> Processing repository: {full_repo_name}", file=sys.stderr
+        )
         # Retrieve stored data for the repo
         data = storage.read(full_repo_name)
         if not data:
@@ -249,10 +248,10 @@ def main():
             REPO_SUMMARIES_DIR, f"{full_repo_name.replace('/', '_')}_summary.csv"
         )
         pd.DataFrame(blob_rows).to_csv(output_file, index=False)
-        # print(
-        #     f"<LFS Analysis> Saved summary for {full_repo_name} to {output_file}",
-        #     file=sys.stderr,
-        # )
+        print(
+            f"<LFS Analysis> Saved summary for {full_repo_name} to {output_file}",
+            file=sys.stderr,
+        )
 
     print("<LFS Analysis> LFS analysis script completed successfully", file=sys.stderr)
 

--- a/scripts/lfs_script.py
+++ b/scripts/lfs_script.py
@@ -134,9 +134,9 @@ def main():
     if database_path is not None and not os.path.isabs(database_path):
         database_path = os.path.join(PROJECT_ROOT, database_path)
     github_organization = config.github_organization
-    output_csv_filename = lfs_script_config.output_csv_filename
-    if output_csv_filename is not None and not os.path.isabs(output_csv_filename):
-        output_csv_path = os.path.join(OUTPUT_DIR, output_csv_filename)
+    output_filename = lfs_script_config.output_filename
+    if output_filename is not None and not os.path.isabs(output_filename):
+        output_file_path = os.path.join(OUTPUT_DIR, output_filename)
     repo_list_file = config.repo_list_file
     if repo_list_file is not None and not os.path.isabs(repo_list_file):
         repo_list_file = os.path.join(PROJECT_ROOT, repo_list_file)
@@ -157,7 +157,7 @@ def main():
 
     print(f"Database Path: {database_path}", file=sys.stderr)
     print(f"GitHub Organization: {github_organization}", file=sys.stderr)
-    print(f"Output CSV Path: {output_csv_path}", file=sys.stderr)
+    print(f"Output File Path: {output_file_path}", file=sys.stderr)
     print(f"Repo file: {repo_list_file}", file=sys.stderr)
     print(f"Soft limit (MB): {soft_limit_mb}", file=sys.stderr)
     print(f"Hard limit (MB): {hard_limit_mb}", file=sys.stderr)
@@ -199,7 +199,7 @@ def main():
     ExcelCompiler().compile(
         storage=storage,
         config=master_csv_config,
-        output_path=output_csv_path,
+        output_path=output_file_path,
         transforms=[
             RepoTreeTransform(
                 soft_limit_mb=soft_limit_mb,
@@ -207,7 +207,7 @@ def main():
             )
         ],
     )
-    print(f"<LFS Analysis> Master summary saved to {output_csv_path}", file=sys.stderr)
+    print(f"<LFS Analysis> Master summary saved to {output_file_path}", file=sys.stderr)
 
     # Ensure output directory exists
     if not os.path.isdir(REPO_SUMMARIES_DIR):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -23,7 +23,6 @@ from core.transforms import (
     RepoTreeTransform,
     ReferenceClassifier,
     TriggerRiskTransform,
-    SOFT_LIMIT,
     TimestampTransform,
     parse_workflow_permissions,
     parse_actions_from_content,
@@ -316,7 +315,7 @@ class TestFlagTransform:
 
 class TestRepoTreeTransform:
     def test_no_repo_tree_returns_unchanged(self):
-        t = RepoTreeTransform()
+        t = RepoTreeTransform(soft_limit_mb=50, hard_limit_mb=100)
         data = RepoData(repo_details=RepoDetails(full_name="o/r", name="r"))
 
         result = t.apply(data)
@@ -324,7 +323,7 @@ class TestRepoTreeTransform:
         assert result.repo_tree_transform is None
 
     def test_no_repo_details_returns_unchanged(self):
-        t = RepoTreeTransform()
+        t = RepoTreeTransform(soft_limit_mb=50, hard_limit_mb=100)
         data = RepoData(
             repo_tree=RepoTreeData(
                 tree=[RepoTreeEntry(path="README.md", type="blob", size=1)]
@@ -336,7 +335,7 @@ class TestRepoTreeTransform:
         assert result.repo_tree_transform is None
 
     def test_builds_processed_summary(self):
-        t = RepoTreeTransform()
+        t = RepoTreeTransform(soft_limit_mb=50, hard_limit_mb=100)
         data = RepoData(
             repo_details=RepoDetails(full_name="o/r", name="r"),
             repo_tree=RepoTreeData(
@@ -345,7 +344,7 @@ class TestRepoTreeTransform:
                     RepoTreeEntry(
                         path="large.bin",
                         type="blob",
-                        size=SOFT_LIMIT + 1,
+                        size=50 * 1024 * 1024 + 1,
                         sha="2",
                     ),
                 ]
@@ -356,7 +355,7 @@ class TestRepoTreeTransform:
 
         assert result.repo_tree_transform is not None
         assert result.repo_tree_transform.repo == "o/r"
-        assert result.repo_tree_transform.largest_blob_bytes == SOFT_LIMIT + 1
+        assert result.repo_tree_transform.largest_blob_bytes == 50 * 1024 * 1024 + 1
         assert result.repo_tree_transform.largest_blob_path == "large.bin"
         assert result.repo_tree_transform.exceeds_soft_limit is True
         assert result.repo_tree_transform.exceeds_hard_limit is False


### PR DESCRIPTION
# Introduction :pencil2:

Resolves / Closes #129 by wiring `scripts/lfs_script.py` to the newly established audit config workflow.

## Resolution :heavy_check_mark:

- Adds `lfs_script` configuration schema to `core/config.py` and corresponding defaults to `config/audit_config.py`
- Updates `scripts/lfs_script.py` to load settings from `config/audit_config.yaml` and `--config-file` arg for custom configs
- `RepoTreeTransform` updated to use configurable soft/hard file size limits.

## Miscellaneous :heavy_plus_sign:

- README updates covering usage of `lfs_script.py` in config-driven manner.

## Notes 🗒️ 

- As part of #128 considerations should be made to consolidate the databases to further optimise performance