### PR TITLE
[GitHub Audit CLI] Extend YAML Config Support: alert_metrics.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,11 +364,15 @@ uv run python scripts/alert_metrics.py [options]
 
 **Options:**
 
-- `--org` - GitHub organisation login (default: ministryofjustice)
-- `--output` - CSV output path (default: github_alerts_limited.csv)
-- `--max-alerts` - Maximum number of alert rows to export (default: 100000)
-- `--repo-limit` - Limit scanned repositories
+- `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
 - `--auth` - Select GitHub authentication method explicitly (pat, app, cli)
+- `--repo` - Select a specific repository for analysis.
+
+**Config Parameters:**
+
+- `max_alerts: <int>` - Maximum number of alerts to pull for analysis across the estate
+- `output_filename: <filename>.csv` - File name for summary report results are exported to, stored in `output/alert_metrics/`
+- `repo_limit: <int>` - Only consider the first `<x>` amount of repositories pulled by the script e.g. `400`, `1000`, etc.
 
 **Output:**
 
@@ -377,14 +381,11 @@ uv run python scripts/alert_metrics.py [options]
 **Examples:**
 
 ```bash
-# Export alerts for org to default CSV
-uv run python scripts/alert_metrics.py
+# Export alerts for org to default CSV, using a given config file and authenticating via PAT
+uv run python scripts/alert_metrics.py --config-file config/audit_config.yaml --auth pat
 
-# Export to custom path with limits
-uv run python scripts/alert_metrics.py --output alerts.csv --max-alerts 5000 --repo-limit 100
-
-# Use specific auth method
-uv run python scripts/alert_metrics.py --auth pat
+# Run script against single repository
+uv run python scripts/alert_metrics.py --config-file config/audit_config.yaml --repo-limit 100
 ```
 
 ### 8. `lfs_script.py` - Assess for Unwanted Large Files within GitHub

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ uv run python scripts/alert_metrics.py [options]
 **Config Parameters:**
 
 - `max_alerts: <int>` - Maximum number of alerts to pull for analysis across the estate
-- `output_filename: <filename>.csv` - File name for summary report results are exported to, stored in `output/alert_metrics/`
+- `output_filename: <filename>.csv` - File name for summary report results are exported to, stored in `output/github_alerts/`
 - `repo_limit: <int>` - Only consider the first `<x>` amount of repositories pulled by the script e.g. `400`, `1000`, etc.
 
 **Output:**
@@ -385,7 +385,7 @@ uv run python scripts/alert_metrics.py [options]
 uv run python scripts/alert_metrics.py --config-file config/audit_config.yaml --auth pat
 
 # Run script against single repository
-uv run python scripts/alert_metrics.py --config-file config/audit_config.yaml --repo-limit 100
+uv run python scripts/alert_metrics.py --config-file config/audit_config.yaml --repo ministryofjustice/example-repo
 ```
 
 ### 8. `lfs_script.py` - Assess for Unwanted Large Files within GitHub

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -5,11 +5,18 @@
 github_organization: "ministryofjustice"
 repo_list_file: "repo_list.yaml"
 
+alert_metrics:
+  max_alerts: 10000
+  output_filename: "github_alerts_limited.csv"
+  repo_limit: 400
+
+
 # Script config for list_repos.py.
 list_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "list_repos.xlsx"
-  repo_limit: 50
+  repo_limit: 400
+  resume: true
   standard_endpoints_only: true
   sort_by_field: "pushed_at"
   sort_ascending: false

--- a/core/config.py
+++ b/core/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 
@@ -28,6 +28,21 @@ class LfsScriptConfig(BaseModel):
     use_cache: bool = (
         True  # whether to use database cache to skip repos already collected
     )
+
+
+class AlertMetricsConfig(BaseModel):
+    """Config for ``alert_metrics.py`` script."""
+
+    output_filename: str = "alert_metrics.csv"  # output file for alert data
+    max_alerts: Optional[int] = None  # max number of alerts to collect (for testing)
+    repo_limit: Optional[int] = None  # max number of repos to audit (for testing)
+
+    @field_validator("repo_limit", "max_alerts", mode="after")
+    @classmethod
+    def must_be_positive(cls, value: Optional[int]) -> Optional[int]:
+        if value is not None and value <= 0:
+            raise ValueError(f"Value must be a positive integer, got {value}")
+        return value
 
 
 class ListReposConfig(BaseModel):
@@ -80,6 +95,7 @@ class AuditConfig(BaseModel):
     github_organization: str = "ministryofjustice"
     repo_list_file: str = "repo_list.yaml"
     lfs_script: LfsScriptConfig = Field(default_factory=LfsScriptConfig)
+    alert_metrics: AlertMetricsConfig = Field(default_factory=AlertMetricsConfig)
     list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
     org_security_posture: OrgSecurityPostureConfig = Field(
         default_factory=OrgSecurityPostureConfig

--- a/scripts/alert_metrics.py
+++ b/scripts/alert_metrics.py
@@ -51,7 +51,7 @@ def parse_args() -> argparse.Namespace:
         "--config-file",
         default=None,
         type=Path,
-        help="Path to YAML config file (optional, defaults to internal/audit_config.yaml)",
+        help="Path to YAML config file (optional, defaults to config/audit_config.yaml)",
     )
     parser.add_argument(
         "--auth",

--- a/scripts/alert_metrics.py
+++ b/scripts/alert_metrics.py
@@ -7,21 +7,18 @@ import datetime as dt
 import pandas as pd
 import os
 import sys
+from pathlib import Path
 from typing import Any, Callable
 
 # add project root to path for core imports
 # TODO: Remove once pyproject.toml is build-system configured
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from core.config import AuditConfig, load_audit_config
 from core.compiler import CsvCompiler
 from core.github_api import fetch_repo_alerts, list_org_repos
 from core.github_client import GitHubHttpClient
 from core.utils import base_directory_setup
-
-# Defaults
-
-DEFAULT_ORG = "ministryofjustice"
-DEFAULT_MAX_ALERTS = 100000
 
 # TODO: PROJECT_ROOT will be removed as an output of base_directory_setup once all scripts updated to use audit_config.yaml for repo_list loading
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
@@ -29,8 +26,6 @@ BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 # Configure Output Directories
 OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, "github_alerts")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
-
-DEFAULT_OUTPUT = os.path.join(OUTPUT_DIR, "github_alerts_limited.csv")
 
 # Alerts Config
 AlertSpec = tuple[str, Callable[[dict[str, Any]], str]]
@@ -52,22 +47,21 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Export repository-level alert metrics via core GitHub modules."
     )
-    parser.add_argument("--org", default=DEFAULT_ORG, help="GitHub organisation login.")
-    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="CSV output path.")
     parser.add_argument(
-        "--max-alerts",
-        type=int,
-        default=DEFAULT_MAX_ALERTS,
-        help="Maximum number of alert rows to export.",
+        "--config-file",
+        default=None,
+        type=Path,
+        help="Path to YAML config file (optional, defaults to internal/audit_config.yaml)",
     )
-    parser.add_argument("--repo-limit", type=int, help="Limit scanned repositories.")
     parser.add_argument(
         "--auth",
         choices=["pat", "app", "cli"],
         default=None,
         help="Select GitHub authentication method explicitly",
     )
-    parser.add_argument("--repo", help="Scan only a single repository (owner/repo).")
+    parser.add_argument(
+        "--repo", default=None, help="Scan only a single repository (owner/repo)."
+    )
     return parser.parse_args()
 
 
@@ -185,30 +179,45 @@ def summarise_results(output_file: str) -> None:
 def main() -> None:
     # Configure and Validate CLI Arguments
     args = parse_args()
-    if args.max_alerts <= 0:
-        print("--max-alerts must be > 0", file=sys.stderr)
-        sys.exit(2)
-    if args.repo_limit is not None and args.repo_limit <= 0:
-        print("--repo-limit must be > 0", file=sys.stderr)
-        sys.exit(2)
+
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    alert_metrics_config = config.alert_metrics
+
+    github_organization = config.github_organization
+    output_filename = alert_metrics_config.output_filename
+    max_alerts = alert_metrics_config.max_alerts
+    repo_limit = alert_metrics_config.repo_limit
+
+    # Debug
+
+    print(f"Using GitHub organization: {github_organization}")
+    print(f"Output file name: {output_filename}")
+    print(f"Max alerts: {max_alerts}")
+    print(f"Repo limit: {repo_limit}")
 
     # Configure GitHub connection and gather Repo Information
     client = GitHubHttpClient(auth_method=args.auth)
     if args.repo:
+        print(f"Scanning single repository: {args.repo}")
         repos = [args.repo]
     else:
-        repos = list_org_repos(args.org, client)
-    if args.repo_limit:
-        repos = repos[: args.repo_limit]
+        print(f"Fetching repositories for organization: {github_organization}")
+        repos = list_org_repos(github_organization, client)
+        if repo_limit:
+            repos = repos[:repo_limit]
+
     # Pre-build archive status lookup so we can annotate each alert with repo status.
     # This helps distinguish between alerts in active vs. archived repositories.
-    archive_status_lookup = build_archive_status_lookup(client, args.org, repos)
+    archive_status_lookup = build_archive_status_lookup(
+        client, github_organization, repos
+    )
 
     rows: list[dict[str, Any]] = []
     repos_with_alerts: set[str] = set()
 
     for repo_full in repos:
-        if len(rows) >= args.max_alerts:
+        if len(rows) >= max_alerts:
             break
 
         # Split Repo Owner and Name from list i.e. owner/repo-name
@@ -217,7 +226,7 @@ def main() -> None:
 
         # Assess repository information for each alert category and severity criteria to be logged
         for kind, severity_of in ALERT_SPECS:
-            if len(rows) >= args.max_alerts:
+            if len(rows) >= max_alerts:
                 break
             try:
                 # Gather repo alerts information for assessment
@@ -228,7 +237,7 @@ def main() -> None:
 
             # Review alerts found for given repo and extract creation/remediation timestamps and lifecycle
             for alert in alerts:
-                if len(rows) >= args.max_alerts:
+                if len(rows) >= max_alerts:
                     break
                 if not isinstance(alert, dict):
                     continue
@@ -263,15 +272,16 @@ def main() -> None:
                 repos_with_alerts.add(repo_full)
 
     # Write rows to final output file
+    output_file_path = os.path.join(OUTPUT_DIR, output_filename)
     if rows:
-        CsvCompiler.write_rows(args.output, rows)
+        CsvCompiler.write_rows(output_file_path, rows)
 
     # Summary logging
-    print(f"Done! Wrote {len(rows)} alerts to {args.output}")
+    print(f"Done! Wrote {len(rows)} alerts to {output_file_path}")
     print(f"Repos with alerts: {len(repos_with_alerts)}")
 
     if rows:
-        summarise_results(args.output)
+        summarise_results(output_file_path)
 
 
 if __name__ == "__main__":

--- a/scripts/alert_metrics.py
+++ b/scripts/alert_metrics.py
@@ -191,10 +191,10 @@ def main() -> None:
 
     # Debug
 
-    print(f"Using GitHub organization: {github_organization}")
-    print(f"Output file name: {output_filename}")
-    print(f"Max alerts: {max_alerts}")
-    print(f"Repo limit: {repo_limit}")
+    print(f"Using GitHub organization: {github_organization}", file=sys.stderr)
+    print(f"Output file name: {output_filename}", file=sys.stderr)
+    print(f"Max alerts: {max_alerts}", file=sys.stderr)
+    print(f"Repo limit: {repo_limit}", file=sys.stderr)
 
     # Configure GitHub connection and gather Repo Information
     client = GitHubHttpClient(auth_method=args.auth)
@@ -217,7 +217,7 @@ def main() -> None:
     repos_with_alerts: set[str] = set()
 
     for repo_full in repos:
-        if len(rows) >= max_alerts:
+        if max_alerts is not None and len(rows) >= max_alerts:
             break
 
         # Split Repo Owner and Name from list i.e. owner/repo-name
@@ -226,7 +226,7 @@ def main() -> None:
 
         # Assess repository information for each alert category and severity criteria to be logged
         for kind, severity_of in ALERT_SPECS:
-            if len(rows) >= max_alerts:
+            if max_alerts is not None and len(rows) >= max_alerts:
                 break
             try:
                 # Gather repo alerts information for assessment
@@ -237,7 +237,7 @@ def main() -> None:
 
             # Review alerts found for given repo and extract creation/remediation timestamps and lifecycle
             for alert in alerts:
-                if len(rows) >= max_alerts:
+                if max_alerts is not None and len(rows) >= max_alerts:
                     break
                 if not isinstance(alert, dict):
                     continue

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,27 @@ def test_load_returns_config_from_file(tmp_path):
     assert config.repo_list_file == "custom_repos.yaml"
 
 
+def test_load_respects_alert_metrics_config(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "alert_metrics": {
+                    "output_filename": "custom_alerts.csv",
+                    "max_alerts": 500,
+                    "repo_limit": 50,
+                }
+            }
+        )
+    )
+
+    config = load_audit_config(config_file)
+
+    assert config.alert_metrics.output_filename == "custom_alerts.csv"
+    assert config.alert_metrics.max_alerts == 500
+    assert config.alert_metrics.repo_limit == 50
+
+
 def test_load_respects_org_security_posture_config_overrides(tmp_path):
     config_file = tmp_path / "audit_config.yaml"
     config_file.write_text(


### PR DESCRIPTION
# Introduction :pencil2:

Closes #137 by wiring `config/audit_config.yaml` up to `scripts/alert_metrics.py` for config-driven execution.

## Resolution :heavy_check_mark:

- Adds `AlertMetricsConfig` to `core/config.py` and corresponding defaults in `config/audit_config.yaml`
- Updates `scripts/alert_metrics.py` to load settings from `config/audit_config.yaml` (with added `--config-file` argument)
- Unit test added to validate config parameter overrides being respected.
- README updated for config-based execuition

## Miscellaneous :heavy_plus_sign:

- Cleanup of duplicated code in `scripts/alert_metrics.py` to allow cleaner single-repo vs full repo set analysis