### PR TITLE
[GitHub Audit CLI] Extend YAML Config Support: archive_repos.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Each repo is assigned risk flags:
 ```bash
 # 1. Audit all repos in organization
 export GITHUB_TOKEN=ghp_xxxx
-uv run python scripts/list_repos.py --repo-file repo_list.yaml --excel audit_results.xlsx
+uv run python scripts/list_repos.py --config-file config/audit_config.yaml
 
 # 2. Launch dashboard to explore results
 uv run python scripts/dashboard.py

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ uv run python scripts/archive_repos.py --config-file path/to/config.yaml --auth 
 **Config Parameters:**
 
 - `database_path: "path/to/file.db"` - SQLite path for core storage (default: `internal/repo_audit.db`).
-- `output_filename: "file.csv"` - Export the full results set to CSV of given filename under `output/archive_repos/`
+- `output_filename: "file.csv / file.xlsx"` - Export the full results set to CSV or Excel of given filename under `output/archive_repos/`
 - `page_num: null/<int>` - Process only one page of cached/fetched repos (100 repos per page, 0-indexed). `null` for full estate.
 - `repo_limit: null/<int>` - Limit the number of repositories loaded from the organisation. `null` for full estate.
 - `sort_by_field: "field"` - Sort by a result column. Default is `days_since_push`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ uv run python scripts/list_repos.py --config-file config/audit_config.yaml --aut
 - `use_cache: true/false` - Skip endpoints already persisted in the database for each repo. Safe to use after an interrupted run.
 - `standard_endpoints_only: true/false` - Use the reduced endpoint set for faster runs. By default, `list_repos.py` collects all repo endpoints.
 - `sort_by_field: <column>` - Sort by repo field. Defaults to last updated (`pushed_at`).
-- `sort_ascending: <true/false>` - Sort order for `sort_by` field, defaults to `false` / descending
+- `sort_ascending: <true/false>` - Sort order for `sort_by_field`, defaults to `false` / descending
 
 **Examples:**
 
@@ -114,30 +114,35 @@ The script caches repo metadata and code-search results locally so repeated runs
 **Usage:**
 
 ```bash
-uv run python scripts/archive_repos.py <org> [options]
+uv run python scripts/archive_repos.py --config-file path/to/config.yaml --auth pat
 ```
 
 **Options:**
 
-- `--csv <path>` - Export the full results set to CSV.
-- `--limit <N>` - Limit the number of repositories loaded from the organisation.
-- `--page-num <N>` - Process only one page of cached/fetched repos (100 repos per page, 0-indexed).
-- `--sort [-]column` - Sort by a result column. Default is `days_since_push` ascending. Prefix with `-` for descending.
-- `--audit-db [path]` - Use a custom SQLite path for core storage persistence. If omitted, the script uses `internal/repo_audit.db` beside the script if present.
-  - If provided without a path, it also defaults to `internal/repo_audit.db`.
-- `--cache-only` - Do not call the GitHub API. Use only existing local caches.
+- `--config-file <path/to/config.yaml>` - Path to config file for audit script to reference, defaults to `config/audit_config.yaml` if not provided.
 - `--auth` - Specify a (single) auth method if required `pat, app, cli` - will default check each method sequentially if not provided.
-- `--namespace-crossref` - Opt-in cross-reference: compare archived repos with namespace folders in a separate repo.
-- `--namespace-repo <name>` - Namespace repository name (default: `cloud-platform-environments`).
-- `--namespace-branch <name>` - Branch to inspect in namespace repository (default: `main`).
-- `--namespace-root <path>` - Top-level namespace directory path (default: `namespaces`).
+
+**Config Parameters:**
+
+- `database_path: "path/to/file.db"` - SQLite path for core storage (default: `internal/repo_audit.db`).
+- `output_filename: "file.csv"` - Export the full results set to CSV of given filename under `output/archive_repos/`
+- `page_num: null/<int>` - Process only one page of cached/fetched repos (100 repos per page, 0-indexed). `null` for full estate.
+- `repo_limit: null/<int>` - Limit the number of repositories loaded from the organisation. `null` for full estate.
+- `sort_by_field: "field"` - Sort by a result column. Default is `days_since_push`
+- `sort_ascending: true/false` - Sort order for `sort_by_field`, defaults to `false` / descending
+- `use_cache: true/false` - Do not call the GitHub API / Use only existing local caches if `true`.
+- **Namespace Crossref Config:**
+  - `enabled: true/false` - Opt-in cross-reference: compare archived repos with namespace folders in a separate repo.
+  - `target_repo: "repo_name"` - Namespace repository name (default: `cloud-platform-environments`).
+  - `target_branch: "branch"` - Branch to inspect in namespace repository (default: `main`).
+  - `root_folder: "folder"` - Top-level namespace directory path (default: `namespaces`).
 
 **Output:**
 
-- CSV when `--csv` is used
-- Core storage is persisted in SQLite (`repo_data` table)
-- JSON to stdout when `--csv` is not provided and `--audit-db` is not explicitly supplied
-- When `--namespace-crossref` is enabled and JSON is printed, output is an object with `records` and `namespace_crossref_summary`
+- CSV to `output/archive_repos`
+- Core storage is persisted in SQLite (`repo_data` table) under `internal/`
+- JSON to stdout by default.
+- When `namespace_crossref` is enabled and JSON is printed, output is an object with `records` and `namespace_crossref_summary`
 - Elapsed time and progress information on stderr
 
 **Useful fields in the output:**
@@ -150,23 +155,8 @@ uv run python scripts/archive_repos.py <org> [options]
 **Examples:**
 
 ```bash
-# Export archive candidates to CSV
-uv run python scripts/archive_repos.py ministryofjustice --csv archivable.csv
-
-# Export archive candidates to CSV, authenticating via PAT specifically
-uv run python scripts/archive_repos.py ministryofjustice --csv archivable.csv --auth pat
-
-# Reuse local caches only for a fast rerun
-uv run python scripts/archive_repos.py ministryofjustice --cache-only --csv archivable.csv
-
-# Process only page 2 of the org inventory and write to the audit database
-uv run python scripts/archive_repos.py ministryofjustice --page-num 2 --audit-db
-
-# Sort by oldest last push and print JSON to stdout
-uv run python scripts/archive_repos.py ministryofjustice --sort days_since_push
-
-# Opt-in: identify archived repos that still have namespace folders
-uv run python scripts/archive_repos.py ministryofjustice --namespace-crossref
+# Export archive candidates to CSV using specific config parameters
+uv run python scripts/archive_repos.py --config-file path/to/config.yaml --auth pat
 ```
 
 ### 3. `org_security_posture.py` - Audit Organisation Security Posture
@@ -471,13 +461,7 @@ uv run python scripts/dashboard.py
 
 ```bash
 # 1. Generate a CSV of old or archived repositories
-uv run python scripts/archive_repos.py ministryofjustice --csv archivable.csv
-
-# 2. Re-run quickly from the local caches while refining filters
-uv run python scripts/archive_repos.py ministryofjustice --cache-only --csv archivable.csv
-
-# 3. Optionally persist to a custom SQLite file for downstream analysis
-uv run python scripts/archive_repos.py ministryofjustice --audit-db /tmp/archive-audit.db
+uv run python scripts/archive_repos.py --config-file config/audit_config.yaml
 ```
 
 ### Organisation Security Posture Review
@@ -583,8 +567,7 @@ uv run python scripts/dashboard.py
 ### Export archive candidate data
 
 ```bash
-uv run python scripts/archive_repos.py ministryofjustice --csv archivable.csv
-uv run python scripts/archive_repos.py ministryofjustice --cache-only --sort -days_since_push
+uv run python scripts/archive_repos.py --config-file config/audit_config.yaml
 ```
 
 ### Export organisation posture report

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -30,11 +30,11 @@ org_security_posture:
 archive_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "archive_repos.csv"
-  page_num: None # None for all pages, or set to an integer to limit
-  repo_limit: None # None for no limit, or set to an integer to limit
+  # page_num: None # None for all pages, or set to an integer to limit
+  # repo_limit: None # None for no limit, or set to an integer to limit
   sort_by_field: "days_since_push"
   sort_ascending: false
-  use_cache: true
+  # use_cache: true
   namespace_crossref:
     enabled: true
     target_repo: "cloud-platform-environments"

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -17,9 +17,9 @@ archive_repos:
   repo_limit: null # null for no limit, or set to an integer to limit
   sort_by_field: "days_since_push"
   sort_ascending: false
-  use_cache: true
+  use_cache: false
   namespace_crossref:
-    enabled: true
+    enabled: false
     target_repo: "cloud-platform-environments"
     target_branch: "main"
     root_folder: "namespaces"

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -13,11 +13,11 @@ alert_metrics:
 archive_repos:
   database_path: "internal/repo_audit.db"
   output_filename: "archive_repos.csv"
-  page_num: None # None for all pages, or set to an integer to limit
-  repo_limit: None # None for no limit, or set to an integer to limit
+  page_num: null # null for all pages, or set to an integer to limit
+  repo_limit: null # null for no limit, or set to an integer to limit
   sort_by_field: "days_since_push"
   sort_ascending: false
-  use_cache: true
+  # use_cache: true
   namespace_crossref:
     enabled: true
     target_repo: "cloud-platform-environments"

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -29,7 +29,9 @@ org_security_posture:
   use_cache: true
 archive_repos:
   database_path: "internal/repo_audit.db"
-  repo_limit: 400
+  output_filename: "archive_repos.csv"
+  page_num: None # None for all pages, or set to an integer to limit
+  repo_limit: None # None for no limit, or set to an integer to limit
   sort_by_field: "days_since_push"
   sort_ascending: false
   use_cache: true
@@ -38,6 +40,7 @@ archive_repos:
     target_repo: "cloud-platform-environments"
     target_branch: "main"
     root_folder: "namespaces"
+  
 
 
 # Script config for github_workflow.py.

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -27,6 +27,18 @@ org_security_posture:
   database_path: "internal/org_security_posture.db"
   output_filename: "org_security_posture.xlsx"
   use_cache: true
+archive_repos:
+  database_path: "internal/repo_audit.db"
+  repo_limit: 400
+  sort_by_field: "days_since_push"
+  sort_ascending: false
+  use_cache: true
+  namespace_crossref:
+    enabled: true
+    target_repo: "cloud-platform-environments"
+    target_branch: "main"
+    root_folder: "namespaces"
+
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -17,7 +17,7 @@ archive_repos:
   repo_limit: null # null for no limit, or set to an integer to limit
   sort_by_field: "days_since_push"
   sort_ascending: false
-  # use_cache: true
+  use_cache: true
   namespace_crossref:
     enabled: true
     target_repo: "cloud-platform-environments"

--- a/config/audit_config.yaml
+++ b/config/audit_config.yaml
@@ -10,6 +10,19 @@ alert_metrics:
   output_filename: "github_alerts_limited.csv"
   repo_limit: 400
 
+archive_repos:
+  database_path: "internal/repo_audit.db"
+  output_filename: "archive_repos.csv"
+  page_num: None # None for all pages, or set to an integer to limit
+  repo_limit: None # None for no limit, or set to an integer to limit
+  sort_by_field: "days_since_push"
+  sort_ascending: false
+  use_cache: true
+  namespace_crossref:
+    enabled: true
+    target_repo: "cloud-platform-environments"
+    target_branch: "main"
+    root_folder: "namespaces"
 
 # Script config for list_repos.py.
 list_repos:
@@ -27,21 +40,6 @@ org_security_posture:
   database_path: "internal/org_security_posture.db"
   output_filename: "org_security_posture.xlsx"
   use_cache: true
-archive_repos:
-  database_path: "internal/repo_audit.db"
-  output_filename: "archive_repos.csv"
-  # page_num: None # None for all pages, or set to an integer to limit
-  # repo_limit: None # None for no limit, or set to an integer to limit
-  sort_by_field: "days_since_push"
-  sort_ascending: false
-  # use_cache: true
-  namespace_crossref:
-    enabled: true
-    target_repo: "cloud-platform-environments"
-    target_branch: "main"
-    root_folder: "namespaces"
-  
-
 
 # Script config for github_workflow.py.
 # Stages 2 and 3 collect the base data the later stages depend on,

--- a/core/config.py
+++ b/core/config.py
@@ -79,7 +79,7 @@ class ArchiveReposConfig(BaseModel):
     sort_by_field: str = "days_since_push"
     sort_ascending: bool = False  # sort order - descending by default
     use_cache: bool = (
-        True  # whether to use database cache to skip endpoints already collected
+        False  # whether to use database cache to skip endpoints already collected
     )
     namespace_crossref: NamespaceCrossrefConfig = Field(
         default_factory=NamespaceCrossrefConfig

--- a/core/config.py
+++ b/core/config.py
@@ -78,9 +78,9 @@ class ArchiveReposConfig(BaseModel):
     )
     sort_by_field: str = "days_since_push"
     sort_ascending: bool = False  # sort order - descending by default
-    # use_cache: bool = (
-    #     True  # whether to use database cache to skip endpoints already collected
-    # )
+    use_cache: bool = (
+        True  # whether to use database cache to skip endpoints already collected
+    )
     namespace_crossref: NamespaceCrossrefConfig = Field(
         default_factory=NamespaceCrossrefConfig
     )

--- a/core/config.py
+++ b/core/config.py
@@ -45,6 +45,47 @@ class AlertMetricsConfig(BaseModel):
         return value
 
 
+class NamespaceCrossrefConfig(BaseModel):
+    """Config for cross-referencing repos with external namespace data."""
+
+    enabled: bool = False  # whether to perform cross-referencing
+    target_repo: str = ""
+    target_branch: str = "main"
+    root_folder: str = ""
+
+    @model_validator(mode="after")
+    def validate_crossref(self) -> "NamespaceCrossrefConfig":
+        for field_name in ["target_repo", "target_branch", "root_folder"]:
+            if self.enabled and not self.__dict__.get(field_name):
+                raise ValueError(
+                    f"Namespace crossref is enabled but '{field_name}' is not set"
+                )
+        return self
+
+
+class ArchiveReposConfig(BaseModel):
+    """Config for ``archive_repos.py`` script."""
+
+    database_path: str = (
+        "internal/repo_audit.db"  # SQLite cache file for repo audit data
+    )
+    output_filename: str = "archive_repos.csv"  # output file for archived repo data
+    page_num: Optional[int] = (
+        None  # page number to process (for pagination of large orgs)
+    )
+    repo_limit: Optional[int] = (
+        None  # limit total number of repos to process (for testing) - set to None for no limit
+    )
+    sort_by_field: str = "days_since_push"
+    sort_ascending: bool = False  # sort order - descending by default
+    use_cache: bool = (
+        True  # whether to use database cache to skip endpoints already collected
+    )
+    namespace_crossref: NamespaceCrossrefConfig = Field(
+        default_factory=NamespaceCrossrefConfig
+    )
+
+
 class ListReposConfig(BaseModel):
     """Config for ``list_repos.py`` script."""
 
@@ -96,6 +137,7 @@ class AuditConfig(BaseModel):
     repo_list_file: str = "repo_list.yaml"
     lfs_script: LfsScriptConfig = Field(default_factory=LfsScriptConfig)
     alert_metrics: AlertMetricsConfig = Field(default_factory=AlertMetricsConfig)
+    archive_repos: ArchiveReposConfig = Field(default_factory=ArchiveReposConfig)
     list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
     org_security_posture: OrgSecurityPostureConfig = Field(
         default_factory=OrgSecurityPostureConfig

--- a/core/config.py
+++ b/core/config.py
@@ -49,9 +49,9 @@ class NamespaceCrossrefConfig(BaseModel):
     """Config for cross-referencing repos with external namespace data."""
 
     enabled: bool = False  # whether to perform cross-referencing
-    target_repo: str = ""
+    target_repo: str = "cloud-platform-environments"
     target_branch: str = "main"
-    root_folder: str = ""
+    root_folder: str = "namespaces"
 
     @model_validator(mode="after")
     def validate_crossref(self) -> "NamespaceCrossrefConfig":
@@ -87,9 +87,9 @@ class ArchiveReposConfig(BaseModel):
 
     @field_validator("page_num", "repo_limit", mode="after")
     @classmethod
-    def must_be_positive(cls, value: Optional[int]) -> Optional[int]:
-        if value is not None and value <= 0:
-            raise ValueError(f"Value must be a positive integer, got {value}")
+    def must_be_non_negative(cls, value: Optional[int]) -> Optional[int]:
+        if value is not None and value < 0:
+            raise ValueError(f"Value must be a non-negative integer, got {value}")
         return value
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, model_validator, field_validator
 
 DEFAULT_CONFIG_PATH = Path("config/audit_config.yaml")
 

--- a/core/config.py
+++ b/core/config.py
@@ -70,17 +70,17 @@ class ArchiveReposConfig(BaseModel):
         "internal/repo_audit.db"  # SQLite cache file for repo audit data
     )
     output_filename: str = "archive_repos.csv"  # output file for archived repo data
-    page_num: Optional[int] = (
-        None  # page number to process (for pagination of large orgs)
-    )
-    repo_limit: Optional[int] = (
-        None  # limit total number of repos to process (for testing) - set to None for no limit
-    )
+    # page_num: Optional[int] = (
+    #     None  # page number to process (for pagination of large orgs)
+    # )
+    # repo_limit: Optional[int] = (
+    #     None  # limit total number of repos to process (for testing) - set to None for no limit
+    # )
     sort_by_field: str = "days_since_push"
     sort_ascending: bool = False  # sort order - descending by default
-    use_cache: bool = (
-        True  # whether to use database cache to skip endpoints already collected
-    )
+    # use_cache: bool = (
+    #     True  # whether to use database cache to skip endpoints already collected
+    # )
     namespace_crossref: NamespaceCrossrefConfig = Field(
         default_factory=NamespaceCrossrefConfig
     )

--- a/core/config.py
+++ b/core/config.py
@@ -70,12 +70,12 @@ class ArchiveReposConfig(BaseModel):
         "internal/repo_audit.db"  # SQLite cache file for repo audit data
     )
     output_filename: str = "archive_repos.csv"  # output file for archived repo data
-    # page_num: Optional[int] = (
-    #     None  # page number to process (for pagination of large orgs)
-    # )
-    # repo_limit: Optional[int] = (
-    #     None  # limit total number of repos to process (for testing) - set to None for no limit
-    # )
+    page_num: Optional[int] = (
+        None  # page number to process (for pagination of large orgs)
+    )
+    repo_limit: Optional[int] = (
+        None  # limit total number of repos to process (for testing) - set to None for no limit
+    )
     sort_by_field: str = "days_since_push"
     sort_ascending: bool = False  # sort order - descending by default
     # use_cache: bool = (
@@ -84,6 +84,13 @@ class ArchiveReposConfig(BaseModel):
     namespace_crossref: NamespaceCrossrefConfig = Field(
         default_factory=NamespaceCrossrefConfig
     )
+
+    @field_validator("page_num", "repo_limit", mode="after")
+    @classmethod
+    def must_be_positive(cls, value: Optional[int]) -> Optional[int]:
+        if value is not None and value <= 0:
+            raise ValueError(f"Value must be a positive integer, got {value}")
+        return value
 
 
 class ListReposConfig(BaseModel):
@@ -135,9 +142,9 @@ class AuditConfig(BaseModel):
 
     github_organization: str = "ministryofjustice"
     repo_list_file: str = "repo_list.yaml"
-    lfs_script: LfsScriptConfig = Field(default_factory=LfsScriptConfig)
     alert_metrics: AlertMetricsConfig = Field(default_factory=AlertMetricsConfig)
     archive_repos: ArchiveReposConfig = Field(default_factory=ArchiveReposConfig)
+    lfs_script: LfsScriptConfig = Field(default_factory=LfsScriptConfig)
     list_repos: ListReposConfig = Field(default_factory=ListReposConfig)
     org_security_posture: OrgSecurityPostureConfig = Field(
         default_factory=OrgSecurityPostureConfig

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -45,9 +45,6 @@ BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
 OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, "archive_repos")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-# Set Default Database Path
-DEFAULT_DB_PATH = os.path.join(BASE_INTERNAL_DIR, "repo_audit.db")
-
 __start_time: float | None = None
 
 
@@ -72,25 +69,6 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         type=Path,
         help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
-    )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        help="Limit the number of repositories loaded from the organisation.",
-    )
-    parser.add_argument(
-        "--page-num",
-        type=int,
-        help="Process one page only (100 repos per page, 0-indexed).",
-    )
-    parser.add_argument(
-        "--audit-db",
-        nargs="?",
-        const=DEFAULT_DB_PATH,
-        help=(
-            "SQLite path for core storage persistence. "
-            "If provided without a path, defaults to repo_audit.db."
-        ),
     )
     parser.add_argument(
         "--cache-only",
@@ -419,6 +397,8 @@ def main() -> None:
     # Define Variables from Config and/or Args
     github_org = config.github_organization
     output_filename = archive_repos_config.output_filename
+    page_num = archive_repos_config.page_num
+    repo_limit = archive_repos_config.repo_limit
     sort_by_field = archive_repos_config.sort_by_field
     sort_asc = archive_repos_config.sort_ascending
     storage_db_path = archive_repos_config.database_path
@@ -426,6 +406,8 @@ def main() -> None:
     # Debug Config
     print(f"GitHub Organization: {github_org}", file=sys.stderr)
     print(f"Output Filename: {output_filename}", file=sys.stderr)
+    print(f"Page Number: {page_num}", file=sys.stderr)
+    print(f"Repo Limit: {repo_limit}", file=sys.stderr)
     print(f"Sort By Field: {sort_by_field}", file=sys.stderr)
     print(f"Sort Ascending: {sort_asc}", file=sys.stderr)
     print(f"Storage DB Path: {storage_db_path}", file=sys.stderr)
@@ -441,13 +423,6 @@ def main() -> None:
         print(f"- Namespace Branch: {namespace_branch}", file=sys.stderr)
         print(f"- Namespace Root Folder: {namespace_root}", file=sys.stderr)
 
-    if args.limit is not None and args.limit < 0:
-        print("--limit must be >= 0", file=sys.stderr)
-        sys.exit(2)
-    if args.page_num is not None and args.page_num < 0:
-        print("--page-num must be >= 0", file=sys.stderr)
-        sys.exit(2)
-
     storage = SqliteRepoStorage(storage_db_path)
     storage.init()
 
@@ -461,15 +436,16 @@ def main() -> None:
             direction="asc",
         )
 
-    if args.limit is not None:
-        repo_list = repo_list[: args.limit]
+    if repo_limit is not None:
+        print(f"Limiting to first {repo_limit} repositories", file=sys.stderr)
+        repo_list = repo_list[:repo_limit]
 
-    if args.page_num is not None:
+    if page_num is not None:
         page_size = 100
-        start_idx = args.page_num * page_size
+        start_idx = page_num * page_size
         end_idx = start_idx + page_size
         print(
-            f"Processing page {args.page_num} (repos {start_idx}-{end_idx})",
+            f"Processing page {page_num} (repos {start_idx}-{end_idx})",
             file=sys.stderr,
         )
         repo_list = repo_list[start_idx:end_idx]
@@ -543,24 +519,23 @@ def main() -> None:
     csv_path = os.path.join(OUTPUT_DIR, output_filename)
     df.to_csv(csv_path, index=False)
     print(f"Wrote {csv_path}", file=sys.stderr)
-    if not args.audit_db:
-        if archive_repos_config.namespace_crossref.enabled:
-            print(
-                json.dumps(
-                    {
-                        "records": records,
-                        "namespace_crossref_summary": namespace_crossref_summary
-                        or {
-                            "namespace_folders_total": 0,
-                            "archived_repos_with_namespace_folder": 0,
-                            "orphaned_namespaces": [],
-                        },
+    if archive_repos_config.namespace_crossref.enabled:
+        print(
+            json.dumps(
+                {
+                    "records": records,
+                    "namespace_crossref_summary": namespace_crossref_summary
+                    or {
+                        "namespace_folders_total": 0,
+                        "archived_repos_with_namespace_folder": 0,
+                        "orphaned_namespaces": [],
                     },
-                    indent=2,
-                )
+                },
+                indent=2,
             )
-        else:
-            print(json.dumps(records, indent=2))
+        )
+    else:
+        print(json.dumps(records, indent=2))
 
     print(f"Processed {len(records)} repositories", file=sys.stderr)
 

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -37,6 +37,9 @@ from core.models import RepoData, RepoDetails
 from core.storage import SqliteRepoStorage
 from core.utils import base_directory_setup
 
+section_break = "\n" + ("=" * 80) + "\n"
+sub_section_break = "\n" + ("-" * 80) + "\n"
+
 # Base Directory Setup for Outputs and Internal Files
 # TODO: PROJECT_ROOT will be removed as an output of base_directory_setup once all scripts updated to use audit_config.yaml for repo_list loading
 BASE_OUTPUT_DIR, BASE_INTERNAL_DIR, PROJECT_ROOT = base_directory_setup()
@@ -69,11 +72,6 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         type=Path,
         help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
-    )
-    parser.add_argument(
-        "--cache-only",
-        action="store_true",
-        help="Skip API collection and use only existing data from the SQLite store.",
     )
     parser.add_argument(
         "--auth",
@@ -402,8 +400,18 @@ def main() -> None:
     sort_by_field = archive_repos_config.sort_by_field
     sort_asc = archive_repos_config.sort_ascending
     storage_db_path = archive_repos_config.database_path
+    use_cache = archive_repos_config.use_cache
 
     # Debug Config
+    print(section_break, file=sys.stderr)
+
+    print(
+        "archive_repos to be executed with the following config values:",
+        file=sys.stderr,
+    )
+
+    print(section_break, file=sys.stderr)
+
     print(f"GitHub Organization: {github_org}", file=sys.stderr)
     print(f"Output Filename: {output_filename}", file=sys.stderr)
     print(f"Page Number: {page_num}", file=sys.stderr)
@@ -411,6 +419,9 @@ def main() -> None:
     print(f"Sort By Field: {sort_by_field}", file=sys.stderr)
     print(f"Sort Ascending: {sort_asc}", file=sys.stderr)
     print(f"Storage DB Path: {storage_db_path}", file=sys.stderr)
+    print(f"Use Cache: {use_cache}", file=sys.stderr)
+
+    print(sub_section_break, file=sys.stderr)
 
     # Namespace cross-ref config
     if archive_repos_config.namespace_crossref.enabled:
@@ -423,12 +434,23 @@ def main() -> None:
         print(f"- Namespace Branch: {namespace_branch}", file=sys.stderr)
         print(f"- Namespace Root Folder: {namespace_root}", file=sys.stderr)
 
+    else:
+        print("Namespace cross-reference disabled", file=sys.stderr)
+
+    print(section_break, file=sys.stderr)
+
     storage = SqliteRepoStorage(storage_db_path)
     storage.init()
 
-    if args.cache_only:
+    print("Storage initialized at", storage_db_path, file=sys.stderr)
+
+    print("Starting repository list collection...", file=sys.stderr)
+
+    if use_cache:
+        print("Loading repository list from cache...", file=sys.stderr)
         repo_list = _list_repos_from_storage(github_org, storage)
     else:
+        print("Collecting repository list from GitHub API...", file=sys.stderr)
         repo_list_collector = RepoListCollector(auth_method=args.auth)
         repo_list = repo_list_collector.collect(
             github_org,
@@ -454,7 +476,13 @@ def main() -> None:
         print("No repositories found for the given selection.", file=sys.stderr)
         return
 
-    if not args.cache_only:
+    print(f"Collected {len(repo_list)} repositories to process", file=sys.stderr)
+
+    if not use_cache:
+        print(
+            "use_cache is False, starting API collection for repository details...",
+            file=sys.stderr,
+        )
         collector = RepoCollector(
             storage=storage,
             auth_method=args.auth,

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -22,6 +23,7 @@ import pandas as pd
 # TODO: Remove once pyproject.toml is build-system configured
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from core.config import AuditConfig, load_audit_config
 from core.collector import RepoCollector, RepoListCollector
 from core.github_api import (
     CodeSearchEndpoint,
@@ -65,8 +67,12 @@ def _parse_args() -> argparse.Namespace:
             "Build an archive-candidate inventory using shared core collectors."
         )
     )
-    parser.add_argument("org", help="GitHub organisation login.")
-    parser.add_argument("--csv", help="Export results to CSV.")
+    parser.add_argument(
+        "--config-file",
+        default=None,
+        type=Path,
+        help=("Path to audit config YAML. Defaults to config/audit_config.yaml."),
+    )
     parser.add_argument(
         "--limit",
         type=int,
@@ -76,13 +82,6 @@ def _parse_args() -> argparse.Namespace:
         "--page-num",
         type=int,
         help="Process one page only (100 repos per page, 0-indexed).",
-    )
-    parser.add_argument(
-        "--sort",
-        help=(
-            "Sort by column. Prefix with '-' for descending or '+' for ascending. "
-            "Default: days_since_push ascending."
-        ),
     )
     parser.add_argument(
         "--audit-db",
@@ -128,16 +127,6 @@ def _parse_args() -> argparse.Namespace:
         help="Top-level folder containing namespace directories (default: namespaces).",
     )
     return parser.parse_args()
-
-
-def _derive_sort(raw_sort: str | None) -> tuple[str, bool]:
-    if not raw_sort:
-        return "days_since_push", True
-    if raw_sort.startswith("-"):
-        return raw_sort[1:], False
-    if raw_sort.startswith("+"):
-        return raw_sort[1:], True
-    return raw_sort, True
 
 
 def _list_repos_from_storage(org: str, storage: SqliteRepoStorage) -> list[str]:
@@ -446,6 +435,24 @@ def main() -> None:
 
     args = _parse_args()
 
+    config: AuditConfig = load_audit_config(args.config_file)
+
+    archive_repos_config = config.archive_repos
+
+    # Define Variables from Config and/or Args
+    github_org = config.github_organization
+    output_filename = archive_repos_config.output_filename
+    sort_by_field = archive_repos_config.sort_by_field
+    sort_asc = archive_repos_config.sort_ascending
+    storage_db_path = archive_repos_config.database_path
+
+    # Debug Config
+    print(f"GitHub Organization: {github_org}", file=sys.stderr)
+    print(f"Output Filename: {output_filename}", file=sys.stderr)
+    print(f"Sort By Field: {sort_by_field}", file=sys.stderr)
+    print(f"Sort Ascending: {sort_asc}", file=sys.stderr)
+    print(f"Storage DB Path: {storage_db_path}", file=sys.stderr)
+
     if args.limit is not None and args.limit < 0:
         print("--limit must be >= 0", file=sys.stderr)
         sys.exit(2)
@@ -453,16 +460,15 @@ def main() -> None:
         print("--page-num must be >= 0", file=sys.stderr)
         sys.exit(2)
 
-    storage_db_path = args.audit_db or DEFAULT_DB_PATH
     storage = SqliteRepoStorage(storage_db_path)
     storage.init()
 
     if args.cache_only:
-        repo_list = _list_repos_from_storage(args.org, storage)
+        repo_list = _list_repos_from_storage(github_org, storage)
     else:
         repo_list_collector = RepoListCollector(auth_method=args.auth)
         repo_list = repo_list_collector.collect(
-            args.org,
+            github_org,
             sort="pushed",
             direction="asc",
         )
@@ -495,7 +501,7 @@ def main() -> None:
                 RepoArchivedAtEndpoint,
             ],
         )
-        collector.collect(args.org, repos=repo_list, resume=True)
+        collector.collect(github_org, repos=repo_list, resume=True)
 
     rows: list[dict[str, Any]] = []
     namespace_crossref_summary: dict[str, Any] | None = None
@@ -504,52 +510,50 @@ def main() -> None:
         data = storage.read(full_name)
         if data is None:
             continue
-        rows.append(_build_row(args.org, full_name, data))
+        rows.append(_build_row(github_org, full_name, data))
 
-    if args.namespace_crossref:
-        namespace_folders = _load_namespace_folders(
-            org=args.org,
-            namespace_repo=args.namespace_repo,
-            namespace_branch=args.namespace_branch,
-            namespace_root=args.namespace_root,
-            auth_method=args.auth,
-        )
-        _apply_namespace_crossref(rows, namespace_folders)
+    # if args.namespace_crossref:
+    #     namespace_folders = _load_namespace_folders(
+    #         org=github_org,
+    #         namespace_repo=args.namespace_repo,
+    #         namespace_branch=args.namespace_branch,
+    #         namespace_root=args.namespace_root,
+    #         auth_method=args.auth,
+    #     )
+    #     _apply_namespace_crossref(rows, namespace_folders)
 
-        archived_repo_names = _list_archived_repo_names_from_storage(args.org, storage)
-        orphaned = sorted(namespace_folders.intersection(archived_repo_names))
+    #     archived_repo_names = _list_archived_repo_names_from_storage(github_org, storage)
+    #     orphaned = sorted(namespace_folders.intersection(archived_repo_names))
 
-        print(
-            f"Namespace cross-reference enabled: {len(orphaned)} archived repo(s) "
-            "still have namespace folders",
-            file=sys.stderr,
-        )
-        if orphaned:
-            print("Archived repos with namespace folders:", file=sys.stderr)
-            for repo_name in orphaned:
-                print(f"- {repo_name}", file=sys.stderr)
+    #     print(
+    #         f"Namespace cross-reference enabled: {len(orphaned)} archived repo(s) "
+    #         "still have namespace folders",
+    #         file=sys.stderr,
+    #     )
+    #     if orphaned:
+    #         print("Archived repos with namespace folders:", file=sys.stderr)
+    #         for repo_name in orphaned:
+    #             print(f"- {repo_name}", file=sys.stderr)
 
-        namespace_crossref_summary = _build_namespace_crossref_summary(
-            rows=rows,
-            namespace_folders=namespace_folders,
-            orphaned=orphaned,
-        )
+    #     namespace_crossref_summary = _build_namespace_crossref_summary(
+    #         rows=rows,
+    #         namespace_folders=namespace_folders,
+    #         orphaned=orphaned,
+    #     )
 
     df = _compute_derived_columns(pd.DataFrame(rows))
 
-    sort_key, sort_asc = _derive_sort(args.sort)
-    if not df.empty and sort_key in df.columns:
-        df = df.sort_values(by=sort_key, ascending=sort_asc, na_position="last")
-    elif sort_key:
-        print(f"Warning: sort key '{sort_key}' not a column", file=sys.stderr)
+    if not df.empty and sort_by_field in df.columns:
+        df = df.sort_values(by=sort_by_field, ascending=sort_asc, na_position="last")
+    elif sort_by_field:
+        print(f"Warning: sort key '{sort_by_field}' not a column", file=sys.stderr)
 
     records = df.to_dict(orient="records")
 
-    if args.csv:
-        csv_path = os.path.join(OUTPUT_DIR, args.csv)
-        df.to_csv(csv_path, index=False)
-        print(f"Wrote {csv_path}", file=sys.stderr)
-    elif not args.audit_db:
+    csv_path = os.path.join(OUTPUT_DIR, output_filename)
+    df.to_csv(csv_path, index=False)
+    print(f"Wrote {csv_path}", file=sys.stderr)
+    if not args.audit_db:
         if args.namespace_crossref:
             print(
                 json.dumps(

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -103,29 +103,6 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="Select GitHub authentication method explicitly",
     )
-    parser.add_argument(
-        "--namespace-crossref",
-        action="store_true",
-        help=(
-            "Cross-reference archived repositories against namespace folders "
-            "in a separate repository (opt-in)."
-        ),
-    )
-    parser.add_argument(
-        "--namespace-repo",
-        default="cloud-platform-environments",
-        help="Repository containing namespace folders (default: cloud-platform-environments).",
-    )
-    parser.add_argument(
-        "--namespace-branch",
-        default="main",
-        help="Branch to inspect in --namespace-repo (default: main).",
-    )
-    parser.add_argument(
-        "--namespace-root",
-        default="namespaces",
-        help="Top-level folder containing namespace directories (default: namespaces).",
-    )
     return parser.parse_args()
 
 
@@ -453,6 +430,17 @@ def main() -> None:
     print(f"Sort Ascending: {sort_asc}", file=sys.stderr)
     print(f"Storage DB Path: {storage_db_path}", file=sys.stderr)
 
+    # Namespace cross-ref config
+    if archive_repos_config.namespace_crossref.enabled:
+        namespace_repo = archive_repos_config.namespace_crossref.target_repo
+        namespace_branch = archive_repos_config.namespace_crossref.target_branch
+        namespace_root = archive_repos_config.namespace_crossref.root_folder
+
+        print("Namespace cross-reference enabled with config:", file=sys.stderr)
+        print(f"- Namespace Repo: {namespace_repo}", file=sys.stderr)
+        print(f"- Namespace Branch: {namespace_branch}", file=sys.stderr)
+        print(f"- Namespace Root Folder: {namespace_root}", file=sys.stderr)
+
     if args.limit is not None and args.limit < 0:
         print("--limit must be >= 0", file=sys.stderr)
         sys.exit(2)
@@ -512,34 +500,36 @@ def main() -> None:
             continue
         rows.append(_build_row(github_org, full_name, data))
 
-    # if args.namespace_crossref:
-    #     namespace_folders = _load_namespace_folders(
-    #         org=github_org,
-    #         namespace_repo=args.namespace_repo,
-    #         namespace_branch=args.namespace_branch,
-    #         namespace_root=args.namespace_root,
-    #         auth_method=args.auth,
-    #     )
-    #     _apply_namespace_crossref(rows, namespace_folders)
+    if archive_repos_config.namespace_crossref.enabled:
+        namespace_folders = _load_namespace_folders(
+            org=github_org,
+            namespace_repo=namespace_repo,
+            namespace_branch=namespace_branch,
+            namespace_root=namespace_root,
+            auth_method=args.auth,
+        )
+        _apply_namespace_crossref(rows, namespace_folders)
 
-    #     archived_repo_names = _list_archived_repo_names_from_storage(github_org, storage)
-    #     orphaned = sorted(namespace_folders.intersection(archived_repo_names))
+        archived_repo_names = _list_archived_repo_names_from_storage(
+            github_org, storage
+        )
+        orphaned = sorted(namespace_folders.intersection(archived_repo_names))
 
-    #     print(
-    #         f"Namespace cross-reference enabled: {len(orphaned)} archived repo(s) "
-    #         "still have namespace folders",
-    #         file=sys.stderr,
-    #     )
-    #     if orphaned:
-    #         print("Archived repos with namespace folders:", file=sys.stderr)
-    #         for repo_name in orphaned:
-    #             print(f"- {repo_name}", file=sys.stderr)
+        print(
+            f"Namespace cross-reference enabled: {len(orphaned)} archived repo(s) "
+            "still have namespace folders",
+            file=sys.stderr,
+        )
+        if orphaned:
+            print("Archived repos with namespace folders:", file=sys.stderr)
+            for repo_name in orphaned:
+                print(f"- {repo_name}", file=sys.stderr)
 
-    #     namespace_crossref_summary = _build_namespace_crossref_summary(
-    #         rows=rows,
-    #         namespace_folders=namespace_folders,
-    #         orphaned=orphaned,
-    #     )
+        namespace_crossref_summary = _build_namespace_crossref_summary(
+            rows=rows,
+            namespace_folders=namespace_folders,
+            orphaned=orphaned,
+        )
 
     df = _compute_derived_columns(pd.DataFrame(rows))
 
@@ -554,7 +544,7 @@ def main() -> None:
     df.to_csv(csv_path, index=False)
     print(f"Wrote {csv_path}", file=sys.stderr)
     if not args.audit_db:
-        if args.namespace_crossref:
+        if archive_repos_config.namespace_crossref.enabled:
             print(
                 json.dumps(
                     {

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -546,9 +546,12 @@ def main() -> None:
 
     records = df.to_dict(orient="records")
 
-    csv_path = os.path.join(OUTPUT_DIR, output_filename)
-    df.to_csv(csv_path, index=False)
-    print(f"Wrote {csv_path}", file=sys.stderr)
+    output_path = Path(OUTPUT_DIR) / output_filename
+    if output_path.suffix.lower() == ".xlsx":
+        df.to_excel(output_path, index=False)
+    else:
+        df.to_csv(output_path, index=False)
+    print(f"Wrote {output_path}", file=sys.stderr)
     if archive_repos_config.namespace_crossref.enabled:
         print(
             json.dumps(

--- a/scripts/archive_repos.py
+++ b/scripts/archive_repos.py
@@ -400,6 +400,8 @@ def main() -> None:
     sort_by_field = archive_repos_config.sort_by_field
     sort_asc = archive_repos_config.sort_ascending
     storage_db_path = archive_repos_config.database_path
+    if storage_db_path and not Path(storage_db_path).is_absolute():
+        storage_db_path = str(Path(PROJECT_ROOT) / storage_db_path)
     use_cache = archive_repos_config.use_cache
 
     # Debug Config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,44 @@ def test_load_returns_config_from_file(tmp_path):
     assert config.repo_list_file == "custom_repos.yaml"
 
 
+def test_load_respects_archive_repos_config_overrides(tmp_path):
+    config_file = tmp_path / "audit_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "repo_list_file": "custom_repos.yaml",
+                "archive_repos": {
+                    "output_filename": "custom_archive_output.xlsx",
+                    "use_cache": False,
+                    "namespace_crossref": {
+                        "enabled": True,
+                        "target_repo": "custom_namespace_repo",
+                        "target_branch": "custom_namespace_branch",
+                        "root_folder": "custom_namespace_root",
+                    },
+                },
+            }
+        )
+    )
+
+    config = load_audit_config(config_file)
+
+    assert config.repo_list_file == "custom_repos.yaml"
+    assert config.archive_repos.output_filename == "custom_archive_output.xlsx"
+    assert config.archive_repos.use_cache is False
+    assert config.archive_repos.namespace_crossref.enabled is True
+    assert (
+        config.archive_repos.namespace_crossref.target_repo == "custom_namespace_repo"
+    )
+    assert (
+        config.archive_repos.namespace_crossref.target_branch
+        == "custom_namespace_branch"
+    )
+    assert (
+        config.archive_repos.namespace_crossref.root_folder == "custom_namespace_root"
+    )
+
+
 def test_load_respects_alert_metrics_config(tmp_path):
     config_file = tmp_path / "audit_config.yaml"
     config_file.write_text(


### PR DESCRIPTION
# Introduction :pencil2:

Closes #130 

## Resolution :heavy_check_mark:

- Add `archive_repos` (and `namespace_crossref`) sections to the Pydantic config model and default `config/audit_config.yaml`.
- Update scripts/archive_repos.py to read its settings from `--config-file` / `audit_config.yaml` instead of bespoke CLI flags.
- Add/extend unit tests and `README `documentation for the new config-driven behavior.